### PR TITLE
Fix Baidu backend for cloudpinyin

### DIFF
--- a/modules/cloudpinyin/cloudpinyin.cpp
+++ b/modules/cloudpinyin/cloudpinyin.cpp
@@ -65,56 +65,15 @@ public:
         curl_easy_setopt(queue->curl(), CURLOPT_URL, url.c_str());
     }
 
-    static inline bool ishex(char ch) {
-        if ((ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'f') ||
-            (ch >= 'A' && ch <= 'F'))
-            return true;
-        return false;
-    }
-
-    static inline unsigned char tohex(char ch) {
-        if (ch >= '0' && ch <= '9')
-            return ch - '0';
-        if (ch >= 'a' && ch <= 'f')
-            return ch - 'a' + 10;
-        if (ch >= 'A' && ch <= 'F')
-            return ch - 'A' + 10;
-        return 0;
-    }
-
     std::string parseResult(CurlQueue *queue) override {
         std::string result(queue->result().begin(), queue->result().end());
-        auto start = result.find("[[[\"");
+        auto start = result.find("[[\"");
         std::string hanzi;
         if (start != std::string::npos) {
-            start += strlen("[[[\"");
+            start += strlen("[[\"");
             auto end = result.find("\",", start);
             if (end != std::string::npos && end > start) {
-                size_t length = end - start;
-                if (length % 6 == 0) {
-                }
-
-                size_t i = start;
-                while (i < end) {
-                    if (result[i] == '\\' && result[i + 1] == 'u') {
-                        if (ishex(result[i + 2]) && ishex(result[i + 3]) &&
-                            ishex(result[i + 4]) && ishex(result[i + 5])) {
-                            auto hi = (tohex(result[i + 2]) << 4) |
-                                      tohex(result[i + 3]);
-                            auto lo = (tohex(result[i + 4]) << 4) |
-                                      tohex(result[i + 5]);
-                            auto c = hi << 8 | lo;
-                            hanzi += utf8::UCS4ToUTF8(c);
-                        } else
-                            break;
-                    }
-
-                    i += 6;
-                }
-
-                if (i != end) {
-                    hanzi.clear();
-                }
+                hanzi = result.substr(start, end - start);
             }
         }
         return hanzi;


### PR DESCRIPTION
百度的返回结果格式进行了更改，举例如下
```
{"0":[["锦瑟无端五十弦",20,{"pinyin":"jin'se'wu'duan'wu'shi'xian","type":"IMEDICT"}]],"1":"jin'se'wu'duan'wu'shi'xian","result":[null]}
```
可以直接取 `[["` 到下一个 `"` 之间的字符串作为结果

顺便提问一下 cloudpinyin 为啥没有找到配置文件呢（没有生成`~/.config/fcitx5/conf/cloudpinyin.conf`，手动创建也不会生效），这让我不得不重新编译以更换后端。。。