### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/tools/scel2org5.cpp
+++ b/tools/scel2org5.cpp
@@ -19,7 +19,11 @@
 
 #include <codecvt>
 #include <cstring>
+#ifdef __FreeBSD__
+#include <sys/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <fcitx-utils/fs.h>
 #include <fcitx-utils/log.h>
 #include <fcitx-utils/stringutils.h>


### PR DESCRIPTION
FreeBSD's endian.h is in sys/. This patch changes the include path.