### PR TITLE
Porting to gcc-10

### DIFF
--- a/modules/pinyinhelper/pinyinlookup.h
+++ b/modules/pinyinhelper/pinyinlookup.h
@@ -20,6 +20,7 @@
 #define _PINYINHELPER_PINYINLOOKUP_H_
 
 #include <cstdint>
+#include <string>
 #include <unordered_map>
 #include <vector>
 


### PR DESCRIPTION
https://gcc.gnu.org/gcc-10/porting_to.html
`<string>` is no longer included by default.