### PR TITLE
Call registerDomain with nullptr (default dir).

### DIFF
--- a/gui/pinyindictmanager/main.cpp
+++ b/gui/pinyindictmanager/main.cpp
@@ -13,7 +13,7 @@ namespace fcitx {
 
 PinyinDictManagerPlugin::PinyinDictManagerPlugin(QObject *parent)
     : FcitxQtConfigUIPlugin(parent) {
-    registerDomain("fcitx5-chinese-addons", FCITX_INSTALL_LOCALEDIR);
+    registerDomain("fcitx5-chinese-addons", nullptr);
 }
 
 FcitxQtConfigUIWidget *PinyinDictManagerPlugin::create(const QString &key) {

--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -283,7 +283,7 @@ private:
 class PinyinEngineFactory : public AddonFactory {
 public:
     AddonInstance *create(AddonManager *manager) override {
-        registerDomain("fcitx5-chinese-addons", FCITX_INSTALL_LOCALEDIR);
+        registerDomain("fcitx5-chinese-addons", nullptr);
         return new PinyinEngine(manager->instance());
     }
 };

--- a/im/table/engine.h
+++ b/im/table/engine.h
@@ -98,7 +98,7 @@ private:
 class TableEngineFactory : public AddonFactory {
 public:
     AddonInstance *create(AddonManager *manager) override {
-        registerDomain("fcitx5-chinese-addons", FCITX_INSTALL_LOCALEDIR);
+        registerDomain("fcitx5-chinese-addons", nullptr);
         return new TableEngine(manager->instance());
     }
 };

--- a/modules/chttrans/chttrans.cpp
+++ b/modules/chttrans/chttrans.cpp
@@ -239,7 +239,7 @@ ChttransIMType Chttrans::convertType(fcitx::InputContext *inputContext) {
 
 class ChttransModuleFactory : public AddonFactory {
     AddonInstance *create(AddonManager *manager) override {
-        registerDomain("fcitx5-chinese-addons", FCITX_INSTALL_LOCALEDIR);
+        registerDomain("fcitx5-chinese-addons", nullptr);
         return new Chttrans(manager->instance());
     }
 };

--- a/modules/fullwidth/fullwidth.cpp
+++ b/modules/fullwidth/fullwidth.cpp
@@ -116,7 +116,7 @@ bool Fullwidth::inWhiteList(InputContext *inputContext) const {
 
 class FullwidthModuleFactory : public AddonFactory {
     AddonInstance *create(AddonManager *manager) override {
-        registerDomain("fcitx5-chinese-addons", FCITX_INSTALL_LOCALEDIR);
+        registerDomain("fcitx5-chinese-addons", nullptr);
         return new Fullwidth(manager->instance());
     }
 };

--- a/modules/pinyinhelper/pinyinhelper.cpp
+++ b/modules/pinyinhelper/pinyinhelper.cpp
@@ -147,7 +147,7 @@ std::string PinyinHelper::prettyStrokeString(const std::string &input) {
 
 class PinyinHelperModuleFactory : public AddonFactory {
     AddonInstance *create(AddonManager *manager) override {
-        registerDomain("fcitx5-chinese-addons", FCITX_INSTALL_LOCALEDIR);
+        registerDomain("fcitx5-chinese-addons", nullptr);
         return new PinyinHelper(manager->instance());
     }
 };


### PR DESCRIPTION
Since fcitx5's `registerDomain` checks its second parameter and override it with some default value when it's `nullptr`
https://github.com/fcitx/fcitx5/blob/963248be645ef0ffc2c3d6a1c599c48ca63c8f3c/src/lib/fcitx-utils/i18n.cpp#L20
chinese-addons can have correct locale files when that path is overriden in fcitx5.

Related: https://github.com/fcitx/fcitx5/pull/390