### PR TITLE
Allow table engine load sc.dict from xdg_data.

### DIFF
--- a/im/table/engine.cpp
+++ b/im/table/engine.cpp
@@ -143,9 +143,22 @@ void TableEngine::save() { ime_->saveAll(); }
 const libime::PinyinDictionary &TableEngine::pinyinDict() {
     if (!pinyinLoaded_) {
         try {
-            pinyinDict_.load(libime::PinyinDictionary::SystemDict,
-                             LIBIME_INSTALL_PKGDATADIR "/sc.dict",
-                             libime::PinyinDictFormat::Binary);
+            const auto &standardPath = StandardPath::global();
+            auto systemDictFile =
+                standardPath.open(StandardPath::Type::Data, "libime/sc.dict", O_RDONLY);
+            if (systemDictFile.isValid()) {
+                boost::iostreams::stream_buffer<
+                    boost::iostreams::file_descriptor_source>
+                    buffer(systemDictFile.fd(),
+                           boost::iostreams::file_descriptor_flags::never_close_handle);
+                std::istream in(&buffer);
+                pinyinDict_.load(libime::PinyinDictionary::SystemDict, in,
+                                 libime::PinyinDictFormat::Binary);
+            } else {
+                pinyinDict_.load(libime::PinyinDictionary::SystemDict,
+                                 LIBIME_INSTALL_PKGDATADIR "/sc.dict",
+                                 libime::PinyinDictFormat::Binary);
+            }
         } catch (const std::exception &) {
         }
         pinyinLoaded_ = true;


### PR DESCRIPTION
Since pinyin is able to load "sc.dict" from `XDG_DATA_DIRS` after b2dac7b33f844966f79526821798624e8202eea8, table engine shoud be able to do so as well ...