### PR TITLE
Clear prediction candidates by BackSpace/Delete on Android.

### DIFF
--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -1130,17 +1130,6 @@ bool PinyinEngine::handleCandidateList(KeyEvent &event) {
             return true;
         }
     }
-#ifdef ANDROID
-    if ((event.key().check(FcitxKey_BackSpace) ||
-         event.key().check(FcitxKey_Delete)) &&
-        !state->predictWords_.empty()) {
-        event.filterAndAccept();
-        inputContext->inputPanel().reset();
-        inputContext->updatePreedit();
-        inputContext->updateUserInterface(UserInterfaceComponent::InputPanel);
-        return true;
-    }
-#endif
 
     if (event.key().checkKeyList(*config_.prevPage)) {
         auto *pageable = candidateList->toPageable();
@@ -1522,7 +1511,12 @@ void PinyinEngine::keyEvent(const InputMethodEntry &entry, KeyEvent &event) {
         inputContext->inputPanel().reset();
         inputContext->updatePreedit();
         inputContext->updateUserInterface(UserInterfaceComponent::InputPanel);
-        if (event.key().check(FcitxKey_Escape)) {
+        if (event.key().check(FcitxKey_Escape)
+#ifdef ANDROID
+         || event.key().check(FcitxKey_BackSpace)
+         || event.key().check(FcitxKey_Delete)
+#endif
+        ) {
             event.filterAndAccept();
             return;
         }

--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -1130,6 +1130,17 @@ bool PinyinEngine::handleCandidateList(KeyEvent &event) {
             return true;
         }
     }
+#ifdef ANDROID
+    if ((event.key().check(FcitxKey_BackSpace) ||
+         event.key().check(FcitxKey_Delete)) &&
+        !state->predictWords_.empty()) {
+        event.filterAndAccept();
+        inputContext->inputPanel().reset();
+        inputContext->updatePreedit();
+        inputContext->updateUserInterface(UserInterfaceComponent::InputPanel);
+        return true;
+    }
+#endif
 
     if (event.key().checkKeyList(*config_.prevPage)) {
         auto *pageable = candidateList->toPageable();


### PR DESCRIPTION
Prediction candidates can be dismissed by pressing <key>Esc</key> on desktop. But on Android, there is unlikely a dedicated key for this purpose.