### PR TITLE
Split sc.dict after CJK ExtB and beyond.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ if (ENABLE_GUI)
 endif()
 
 find_package(Boost 1.61 REQUIRED COMPONENTS iostreams)
-find_package(LibIMEPinyin 1.0.11 REQUIRED)
+find_package(LibIMEPinyin 1.0.14 REQUIRED)
 find_package(LibIMETable 1.0.12 REQUIRED)
 
 if (ENABLE_CLOUDPINYIN)

--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -27,6 +27,12 @@
 
 namespace fcitx {
 
+#ifdef ANDROID
+static constexpr bool isAndroid = true;
+#else
+static constexpr bool isAndroid = false;
+#endif
+
 struct OptionalHideInDescription {
     void setHidden(bool hidden) { hidden_ = hidden; }
 
@@ -97,6 +103,9 @@ FCITX_CONFIGURATION(
     Option<bool> spellEnabled{this, "SpellEnabled", _("Enable Spell"), true};
     Option<bool> emojiEnabled{this, "EmojiEnabled", _("Enable Emoji"), true};
     Option<bool> chaiziEnabled{this, "ChaiziEnabled", _("Enable Chaizi"), true};
+    Option<bool> extBEnabled{this, "ExtBEnabled",
+                             _("Enable Characters in Unicode CJK Extension B"),
+                             !isAndroid};
     OptionWithAnnotation<bool, OptionalHideInDescription> cloudPinyinEnabled{
         this, "CloudPinyinEnabled", _("Enable Cloud Pinyin"), false};
     Option<int, IntConstrain, DefaultMarshaller<int>, OptionalHideInDescription>
@@ -108,12 +117,7 @@ FCITX_CONFIGURATION(
     Option<bool> preeditCursorPositionAtBeginning{
         this, "PreeditCursorPositionAtBeginning",
         _("Fix embedded preedit cursor at the beginning of the preedit"),
-#ifdef ANDROID
-        false
-#else
-        true
-#endif
-    };
+        !isAndroid};
     Option<bool> showActualPinyinInPreedit{
         this, "PinyinInPreedit", _("Show complete pinyin in preedit"), false};
     Option<bool> predictionEnabled{this, "Prediction", _("Enable Prediction"),
@@ -317,6 +321,8 @@ private:
     FCITX_ADDON_DEPENDENCY_LOADER(imeapi, instance_->addonManager());
 
     bool hasCloudPinyin_ = false;
+
+    static constexpr size_t NumBuiltInDict = 3;
 };
 
 class PinyinEngineFactory : public AddonFactory {


### PR DESCRIPTION
This method required a modified verison of `sc.dict` and `extb.dict`, I wrote a script (in JavaScript) to do it: https://gist.github.com/rocka/7a8e101f81de1e1fcef6c2d39b88246d

[dict_simp.txt](https://github.com/fcitx/fcitx5-chinese-addons/files/9053988/dict_simp.txt)
[dict_extb.txt](https://github.com/fcitx/fcitx5-chinese-addons/files/9053984/dict_extb.txt)
