### PR TITLE
Always clear predictWords when nothing to predict.

### DIFF
--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -310,6 +310,8 @@ void PinyinEngine::initPredict(InputContext *inputContext) {
     if (auto candidateList = predictCandidateList(words)) {
         auto &inputPanel = inputContext->inputPanel();
         inputPanel.setCandidateList(std::move(candidateList));
+    } else {
+        state->predictWords_.clear();
     }
     inputContext->updatePreedit();
     inputContext->updateUserInterface(UserInterfaceComponent::InputPanel);
@@ -1567,8 +1569,8 @@ void PinyinEngine::keyEvent(const InputMethodEntry &entry, KeyEvent &event) {
         inputContext->updateUserInterface(UserInterfaceComponent::InputPanel);
         if (event.key().check(FcitxKey_Escape)
 #ifdef ANDROID
-            || event.key().check(FcitxKey_BackSpace) ||
-            event.key().check(FcitxKey_Delete)
+            || event.key().check(FcitxKey_BackSpace)
+            || event.key().check(FcitxKey_Delete)
 #endif
         ) {
             event.filterAndAccept();


### PR DESCRIPTION
On Android, after typing a character that does not have any prediction, such as 𰻝(biang), you need to press <kbd>BackSpace</kbd> twice to delete the character. But seems can't reproduce on desktop.

https://github.com/fcitx/fcitx5-chinese-addons/blob/ba0ad5b92782a0c28c0a82367fcce761595f7582/im/pinyin/pinyin.cpp#L1563-L1577

This section only checks `state->predictWords_` for prediction handling, but when `PinyinEngine::initPredict` didn't produce a CandidateList, `predictWords_` is not empty, and it would consume a <kbd>BackSpace</kbd> key press on Android.