### PR TITLE
Fix chttrans convertType detection for traditional chinese input methods

### DIFF
--- a/modules/chttrans/chttrans.cpp
+++ b/modules/chttrans/chttrans.cpp
@@ -236,7 +236,7 @@ ChttransIMType Chttrans::convertType(fcitx::InputContext *inputContext) const {
     }
 
     if (!enabledIM_.count(entry->uniqueName())) {
-        return ChttransIMType::Other;
+        return type;
     }
 
     return type == ChttransIMType::Simp ? ChttransIMType::Trad


### PR DESCRIPTION
When chttrans is disabled for certain input method, convertType for this input method should be it's inputMethodType, rather than `ChttransIMType::Other`. Otherwise, status area cannot show proper icon for it.

Since the icon for `Simp` and `Other` are both `"fcitx-chttrans-inactive"`, it's not possible to distinguish traditional chinese input methods' enabled state.