### PR TITLE
Reduce compiler warnings and improve OpenCC logging

### DIFF
--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -238,10 +238,10 @@ FCITX_CONFIGURATION(
                            {_("Enter a string from the list will make it enter "
                               "quickphrase mode.")}};
     Option<FuzzyConfig> fuzzyConfig{this, "Fuzzy", _("Fuzzy Pinyin Settings")};
-    HiddenOption<bool> firstRun{this, "FirstRun", "FirstRun", true};);
+    HiddenOption<bool> firstRun{this, "FirstRun", "FirstRun", true};)
 
 class PinyinState;
-class EventSourceTime;
+struct EventSourceTime;
 class CandidateList;
 
 class PinyinEngine final : public InputMethodEngineV3 {
@@ -343,8 +343,6 @@ private:
     FCITX_ADDON_DEPENDENCY_LOADER(pinyinhelper, instance_->addonManager());
     FCITX_ADDON_DEPENDENCY_LOADER(spell, instance_->addonManager());
     FCITX_ADDON_DEPENDENCY_LOADER(imeapi, instance_->addonManager());
-
-    bool hasCloudPinyin_ = false;
 
     static constexpr size_t NumBuiltInDict = 3;
 };

--- a/im/table/state.h
+++ b/im/table/state.h
@@ -21,7 +21,7 @@ enum class TableMode {
     LookupPinyin,
 };
 
-class EventSourceTime;
+struct EventSourceTime;
 
 class TableState : public InputContextProperty {
 public:

--- a/modules/chttrans/chttrans-opencc.cpp
+++ b/modules/chttrans/chttrans-opencc.cpp
@@ -27,11 +27,13 @@ void OpenCCBackend::updateConfig(const ChttransConfig &config) {
         s2tProfile = OPENCC_DEFAULT_CONFIG_SIMP_TO_TRAD;
     }
     auto s2tProfilePath = locateProfile(s2tProfile);
+    FCITX_DEBUG() << "s2tProfilePath: " << s2tProfilePath;
 
     try {
         auto s2t = std::make_unique<opencc::SimpleConverter>(s2tProfilePath);
         s2t_ = std::move(s2t);
     } catch (const std::exception &e) {
+        FCITX_WARN() << "exception when loading s2t profile: " << e.what();
     }
 
     auto t2sProfile = *config.openCCT2SProfile;
@@ -39,11 +41,13 @@ void OpenCCBackend::updateConfig(const ChttransConfig &config) {
         t2sProfile = OPENCC_DEFAULT_CONFIG_TRAD_TO_SIMP;
     }
     auto t2sProfilePath = locateProfile(t2sProfile);
+    FCITX_DEBUG() << "t2sProfilePath: " << t2sProfilePath;
 
     try {
         auto t2s = std::make_unique<opencc::SimpleConverter>(t2sProfilePath);
         t2s_ = std::move(t2s);
     } catch (const std::exception &e) {
+        FCITX_WARN() << "exception when loading t2s profile: " << e.what();
     }
 }
 


### PR DESCRIPTION
- declare EventSourceTime as struct according to https://github.com/fcitx/fcitx5/blob/833b0d44d1450d8f3a205b24eda9fc4e4ade4945/src/lib/fcitx-utils/event.h#L57
- remove unused variable `hasCloudPinyin_`
- improve logging when loading opencc profiles