### PR TITLE
Add an option to control commit preview in application.

### DIFF
--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -576,10 +576,8 @@ std::pair<Text, Text> PinyinEngine::preedit(InputContext *inputContext) const {
     const auto &context = state->context_;
     auto preeditWithCursor = context.preeditWithCursor();
     // client preedit can be empty/pinyin/preview depends on config
-    Text clientPreedit;
+    Text clientPreedit, preedit;
     switch (mode) {
-    case PreeditMode::No:
-        break;
     case PreeditMode::ComposingPinyin:
         if (*config_.preeditCursorPositionAtBeginning) {
             clientPreedit.append(
@@ -602,12 +600,12 @@ std::pair<Text, Text> PinyinEngine::preedit(InputContext *inputContext) const {
         } else {
             clientPreedit.setCursor(context.selectedSentence().size());
         }
+        [[fallthrough]];
+    case PreeditMode::No:
+        preedit.append(preeditWithCursor.first);
+        preedit.setCursor(preeditWithCursor.second);
         break;
     }
-
-    // preedit is always composing pinyin
-    Text preedit(preeditWithCursor.first);
-    preedit.setCursor(preeditWithCursor.second);
     return {std::move(clientPreedit), std::move(preedit)};
 }
 

--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -570,8 +570,14 @@ std::pair<Text, Text> PinyinEngine::preedit(InputContext *inputContext) const {
     // Use const ref to avoid accidentally change anything.
     const auto &context = state->context_;
     auto preeditWithCursor = context.preeditWithCursor();
+    Text preedit;
     Text clientPreedit;
-    if (*config_.showPreeditInApplication) {
+    switch (*config_.showPreeditInApplication) {
+    case ShowPreeditInApplicationEnum::No:
+        preedit.append(preeditWithCursor.first);
+        preedit.setCursor(preeditWithCursor.second);
+        break;
+    case ShowPreeditInApplicationEnum::ComposingPinyin:
         if (*config_.preeditCursorPositionAtBeginning) {
             clientPreedit.append(
                 preeditWithCursor.first.substr(0, preeditWithCursor.second),
@@ -585,17 +591,18 @@ std::pair<Text, Text> PinyinEngine::preedit(InputContext *inputContext) const {
                                  TextFormatFlag::Underline);
             clientPreedit.setCursor(preeditWithCursor.second);
         }
-    } else if (*config_.showCommitPreviewInApplication) {
+        break;
+    case ShowPreeditInApplicationEnum::CommitPreview:
+        preedit.append(preeditWithCursor.first);
+        preedit.setCursor(preeditWithCursor.second);
         clientPreedit.append(context.sentence(), TextFormatFlag::Underline);
         if (*config_.preeditCursorPositionAtBeginning) {
             clientPreedit.setCursor(0);
         } else {
             clientPreedit.setCursor(context.selectedSentence().size());
         }
+        break;
     }
-
-    Text preedit(preeditWithCursor.first);
-    preedit.setCursor(preeditWithCursor.second);
     return {std::move(clientPreedit), std::move(preedit)};
 }
 
@@ -616,14 +623,10 @@ PinyinEngine::preeditCommitString(InputContext *inputContext) const {
 void PinyinEngine::updatePreedit(InputContext *inputContext) const {
     auto &inputPanel = inputContext->inputPanel();
     auto [clientPreedit, preedit] = this->preedit(inputContext);
-    if (inputContext->capabilityFlags().test(CapabilityFlag::Preedit)) {
+    if (inputContext->isPreeditEnabled()) {
         inputPanel.setClientPreedit(clientPreedit);
     }
-
-    if (!config_.showPreeditInApplication.value() ||
-        !inputContext->capabilityFlags().test(CapabilityFlag::Preedit)) {
-        inputPanel.setPreedit(preedit);
-    }
+    inputPanel.setPreedit(preedit);
 }
 
 void PinyinEngine::updatePuncPreedit(InputContext *inputContext) const {
@@ -2375,7 +2378,10 @@ void PinyinEngine::invokeActionImpl(const InputMethodEntry &entry,
     auto preeditWithCursor = context.preeditWithCursor();
     auto selectedSentence = context.selectedSentence();
     // The logic here need to match ::preedit()
-    if (*config_.showPreeditInApplication) {
+    switch (*config_.showPreeditInApplication) {
+    case ShowPreeditInApplicationEnum::No:
+        break;
+    case ShowPreeditInApplicationEnum::ComposingPinyin:
         if (utf8::length(selectedSentence) > cursor) {
             // If cursor is with in selected sentence range, cancel until cursor
             // is covered.
@@ -2405,12 +2411,14 @@ void PinyinEngine::invokeActionImpl(const InputMethodEntry &entry,
                 state->context_.setCursor(context.cursor() - 1);
             }
         }
-    } else {
+        break;
+    case ShowPreeditInApplicationEnum::CommitPreview:
         if (utf8::length(selectedSentence) > cursor) {
             do {
                 context.cancel();
             } while (utf8::length(context.selectedSentence()) > cursor);
         }
+        break;
     }
     updateUI(inputContext);
 }

--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -585,7 +585,7 @@ std::pair<Text, Text> PinyinEngine::preedit(InputContext *inputContext) const {
                                  TextFormatFlag::Underline);
             clientPreedit.setCursor(preeditWithCursor.second);
         }
-    } else {
+    } else if (*config_.showCommitPreviewInApplication) {
         clientPreedit.append(context.sentence(), TextFormatFlag::Underline);
         if (*config_.preeditCursorPositionAtBeginning) {
             clientPreedit.setCursor(0);

--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -137,8 +137,7 @@ FCITX_CONFIGURATION(
                                    _("Always show Cloud Pinyin place holder"),
                                    false};
     OptionWithAnnotation<ShowPreeditInApplicationEnum,
-                         OptionalHideInDescriptionBase<
-                             ShowPreeditInApplicationEnumI18NAnnotation>>
+                         ShowPreeditInApplicationEnumI18NAnnotation>
         showPreeditInApplication{
             this, "PreeditInApplication", _("Show preedit within application"),
             isAndroid() ? ShowPreeditInApplicationEnum::No

--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -139,6 +139,11 @@ FCITX_CONFIGURATION(
         !isAndroid()};
     Option<bool> showActualPinyinInPreedit{
         this, "PinyinInPreedit", _("Show complete pinyin in preedit"), false};
+    Option<bool> showCommitPreviewInApplication{
+        this,
+        "CommitPreviewInApplication",
+        _("Show commit preview within application"),
+        !isAndroid()};
     Option<bool> predictionEnabled{this, "Prediction", _("Enable Prediction"),
                                    isAndroid() ? true : false};
     Option<int, IntConstrain> predictionSize{

--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -72,11 +72,10 @@ FCITX_CONFIG_ENUM_I18N_ANNOTATION(ShuangpinProfileEnum, N_("Ziranma"), N_("MS"),
                                   N_("Zhongwenzhixing"), N_("PinyinJiajia"),
                                   N_("Xiaohe"), N_("Custom"))
 
-enum class ShowPreeditInApplicationEnum { No, ComposingPinyin, CommitPreview };
+enum class PreeditMode { No, ComposingPinyin, CommitPreview };
 
-FCITX_CONFIG_ENUM_NAME_WITH_I18N(ShowPreeditInApplicationEnum,
-                                 N_("Do not show"), N_("Composing pinyin"),
-                                 N_("Commit preview"))
+FCITX_CONFIG_ENUM_NAME_WITH_I18N(PreeditMode, N_("Do not show"),
+                                 N_("Composing pinyin"), N_("Commit preview"))
 
 FCITX_CONFIGURATION(
     FuzzyConfig, Option<bool> ue{this, "VE_UE", _("ue -> ve"), true};
@@ -136,12 +135,9 @@ FCITX_CONFIGURATION(
         keepCloudPinyinPlaceHolder{this, "KeepCloudPinyinPlaceHolder",
                                    _("Always show Cloud Pinyin place holder"),
                                    false};
-    OptionWithAnnotation<ShowPreeditInApplicationEnum,
-                         ShowPreeditInApplicationEnumI18NAnnotation>
-        showPreeditInApplication{
-            this, "PreeditInApplication", _("Show preedit within application"),
-            isAndroid() ? ShowPreeditInApplicationEnum::No
-                        : ShowPreeditInApplicationEnum::ComposingPinyin};
+    OptionWithAnnotation<PreeditMode, PreeditModeI18NAnnotation> preeditMode{
+        this, "PreeditMode", _("Preedit Mode"),
+        isAndroid() ? PreeditMode::No : PreeditMode::ComposingPinyin};
     Option<bool> preeditCursorPositionAtBeginning{
         this, "PreeditCursorPositionAtBeginning",
         _("Fix embedded preedit cursor at the beginning of the preedit"),

--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -72,6 +72,12 @@ FCITX_CONFIG_ENUM_I18N_ANNOTATION(ShuangpinProfileEnum, N_("Ziranma"), N_("MS"),
                                   N_("Zhongwenzhixing"), N_("PinyinJiajia"),
                                   N_("Xiaohe"), N_("Custom"))
 
+enum class ShowPreeditInApplicationEnum { No, ComposingPinyin, CommitPreview };
+
+FCITX_CONFIG_ENUM_NAME_WITH_I18N(ShowPreeditInApplicationEnum,
+                                 N_("Do not show"), N_("Composing pinyin"),
+                                 N_("Commit preview"))
+
 FCITX_CONFIGURATION(
     FuzzyConfig, Option<bool> ue{this, "VE_UE", _("ue -> ve"), true};
     Option<bool> commonTypo{this, "NG_GN", _("Common Typo"), true};
@@ -130,22 +136,21 @@ FCITX_CONFIGURATION(
         keepCloudPinyinPlaceHolder{this, "KeepCloudPinyinPlaceHolder",
                                    _("Always show Cloud Pinyin place holder"),
                                    false};
-    Option<bool> showPreeditInApplication{this, "PreeditInApplication",
-                                          _("Show preedit within application"),
-                                          true};
+    OptionWithAnnotation<ShowPreeditInApplicationEnum,
+                         OptionalHideInDescriptionBase<
+                             ShowPreeditInApplicationEnumI18NAnnotation>>
+        showPreeditInApplication{
+            this, "PreeditInApplication", _("Show preedit within application"),
+            isAndroid() ? ShowPreeditInApplicationEnum::No
+                        : ShowPreeditInApplicationEnum::ComposingPinyin};
     Option<bool> preeditCursorPositionAtBeginning{
         this, "PreeditCursorPositionAtBeginning",
         _("Fix embedded preedit cursor at the beginning of the preedit"),
         !isAndroid()};
     Option<bool> showActualPinyinInPreedit{
         this, "PinyinInPreedit", _("Show complete pinyin in preedit"), false};
-    Option<bool> showCommitPreviewInApplication{
-        this,
-        "CommitPreviewInApplication",
-        _("Show commit preview within application"),
-        !isAndroid()};
     Option<bool> predictionEnabled{this, "Prediction", _("Enable Prediction"),
-                                   isAndroid() ? true : false};
+                                   isAndroid()};
     Option<int, IntConstrain> predictionSize{
         this, "PredictionSize", _("Prediction Size"), 14, IntConstrain(3, 40)};
     OptionWithAnnotation<SwitchInputMethodBehavior,


### PR DESCRIPTION
**Current behavior:** There is no option to turn on/off commit preview. Preedit has either to be turned off completely in global options (which disables preedit in all input methods), or turned on with both commit preview in application and composing pinyin in input panel.

<table>
  <tbody>
    <tr>
      <td colspan="2" rowspan="2"></td>
      <th align="center" colspan="2">global/PreeditEnabledByDefault</td>
    </tr>
    <tr>
      <td align="center">true</td>
      <td align="center">false</td>
    </tr>
    <tr>
      <th align="center" rowspan="2">pinyin/PreeditInApplication</td>
      <td>true</td>
      <td><img src="https://github.com/fcitx/fcitx5-chinese-addons/assets/13914967/5b9e8127-992f-4459-ab56-d4ce7dec602d"></td>
      <td rowspan="2"><img src="https://github.com/fcitx/fcitx5-chinese-addons/assets/13914967/2df9ad55-eac8-4f10-be55-ad1a5e0a7695"><p>(not ideal because it would disable preedit in all input methods)</p></td>
    </tr>
    <tr>
      <td>false</td>
      <td><img src="https://github.com/fcitx/fcitx5-chinese-addons/assets/13914967/4fc5deda-b814-4bfc-aedf-d92fc8afeb17"></td>
    </tr>
  </tbody>
</table>

<details>
<summary>(outdated)</summary>

**Improved behavior:** Add an new option "Show commit preview within application", allow controling pinyin commit preview separately.

With **global/PreeditEnabledByDefault: true**  and **pinyin/PreeditInApplication: false**, the new option could control commit preview:

<table>
  <tbody>
    <tr>
      <td colspan="2" rowspan="2"></td>
      <th align="center" colspan="2">pinyin/CommitPreviewInApplication</td>
    </tr>
    <tr>
      <td align="center">true</td>
      <td align="center">false</td>
    </tr>
    <tr>
      <th align="center" rowspan="2">pinyin/PreeditInApplication</td>
      <td>false</td>
      <td><img src="https://github.com/fcitx/fcitx5-chinese-addons/assets/13914967/4fc5deda-b814-4bfc-aedf-d92fc8afeb17"></td>
      <td><img src="https://github.com/fcitx/fcitx5-chinese-addons/assets/13914967/2df9ad55-eac8-4f10-be55-ad1a5e0a7695"></td>
    </tr>
  </tbody>
</table>

</details>

**Improved behavior:** Change option "Show commit preview within application" to enum with 3 possible values: `No`, `ComposingPinyin` and `CommitPreview`:

|No (default on Android)|Composing Pinyin (default on desktop)|CommitPreview|
|:-:|:-:|:-:|
|![no](https://github.com/fcitx/fcitx5-chinese-addons/assets/13914967/2df9ad55-eac8-4f10-be55-ad1a5e0a7695)|![composing](https://github.com/fcitx/fcitx5-chinese-addons/assets/13914967/5b9e8127-992f-4459-ab56-d4ce7dec602d)|![commit](https://github.com/fcitx/fcitx5-chinese-addons/assets/13914967/4fc5deda-b814-4bfc-aedf-d92fc8afeb17)|

BTW, I can't see how the "commit preview" is useful. When typing a short phrase, it's just the first candidate. When typing a long sentence, you either get the right sentence in the 1st or 2nd candidate, or have to choose characters manually. In the former case, the "commit preview" just shows the 1st candidate like what it does when typing a short phrase. In the latter case, it would show "the remaining sentence" as if you have chosen the 1st candidate for all the remaining pinyin, but you never get to commit this sentence at once, and still have to choose characters one by one. The "commit preview" just did not provide more infomation than the candidate list, maybe it should just be removed ...
