### PR TITLE
Fix stroke filter candidate action

### DIFF
--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -1464,8 +1464,18 @@ void PinyinEngine::updateStroke(InputContext *inputContext) {
                 }
             }
             if (strokeMatched) {
-                candidateList->append<StrokeFilterCandidateWord>(
-                    this, inputContext, candidate.text(), i);
+                // PinyinCandidateWord is the only forgettable.
+                if (dynamic_cast<const PinyinCandidateWord *>(&candidate)) {
+                    candidateList->append<StrokeFilterCandidateWord<
+                        FilteredForgettableCandidate,
+                        FilteredInsertableAsCustomPhrase>>(this, inputContext,
+                                                           candidate.text(), i);
+                } else if (dynamic_cast<const InsertableAsCustomPhraseInterface
+                                            *>(&candidate)) {
+                    candidateList->append<StrokeFilterCandidateWord<
+                        FilteredInsertableAsCustomPhrase>>(this, inputContext,
+                                                           candidate.text(), i);
+                }
             }
         }
     }

--- a/im/pinyin/pinyincandidate.h
+++ b/im/pinyin/pinyincandidate.h
@@ -123,21 +123,38 @@ private:
     std::string word_;
 };
 
-class StrokeFilterCandidateWord : public CandidateWord,
-                                  public InsertableAsCustomPhraseInterface,
-                                  public ForgettableCandidateInterface {
+class FilteredCandidateWord : public CandidateWord {
 public:
-    StrokeFilterCandidateWord(PinyinEngine *engine, InputContext *inputContext,
-                              Text text, int index);
+    FilteredCandidateWord(PinyinEngine *engine, InputContext *inputContext,
+                          Text text, int index);
 
     void select(InputContext *inputContext) const override;
-    std::string customPhraseString() const override;
-    size_t candidateIndex() const override;
+
+    int originalIndex() const { return index_; }
+    PinyinEngine *engine() const { return engine_; }
+    InputContext *inputContext() const { return inputContext_; }
 
 private:
     PinyinEngine *engine_;
     InputContext *inputContext_;
     int index_;
+};
+
+class FilteredInsertableAsCustomPhrase
+    : public InsertableAsCustomPhraseInterface {
+public:
+    std::string customPhraseString() const override;
+};
+
+class FilteredForgettableCandidate : public ForgettableCandidateInterface {
+public:
+    size_t candidateIndex() const override;
+};
+
+template <typename... Args>
+class StrokeFilterCandidateWord : public FilteredCandidateWord, public Args... {
+public:
+    using FilteredCandidateWord::FilteredCandidateWord;
 };
 
 class ForgetCandidateWord : public CandidateWord {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 add_executable(testpinyinhelper testpinyinhelper.cpp)
 target_link_libraries(testpinyinhelper Fcitx5::Core Fcitx5::Module::PinyinHelper)
-add_dependencies(testpinyinhelper pinyinhelper pinyinhelper.conf.in-fmt)
+add_dependencies(testpinyinhelper pinyin pinyin.conf.in-fmt pinyinhelper pinyinhelper.conf.in-fmt)
 add_test(NAME testpinyinhelper COMMAND testpinyinhelper)
 
 add_executable(testfullwidth testfullwidth.cpp)


### PR DESCRIPTION
Filtering candidates wrongly assume candidate can only be pinyin
candidate type. Use dynamic_cast to insert candidate that can be casted.
