### PR TITLE
Add dependency for shuangpin.conf

### DIFF
--- a/test/inputmethod/CMakeLists.txt
+++ b/test/inputmethod/CMakeLists.txt
@@ -1,5 +1,6 @@
-add_custom_target(copy-im DEPENDS pinyin.conf.in-fmt erbi.conf.in-fmt wbx.conf.in-fmt)
+add_custom_target(copy-im DEPENDS pinyin.conf.in-fmt shuangpin.conf.in-fmt erbi.conf.in-fmt wbx.conf.in-fmt)
 add_custom_command(TARGET copy-im COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/im/pinyin/pinyin.conf ${CMAKE_CURRENT_BINARY_DIR}/pinyin.conf)
+add_custom_command(TARGET copy-im COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/im/pinyin/pinyin.conf ${CMAKE_CURRENT_BINARY_DIR}/shuangpin.conf)
 add_custom_command(TARGET copy-im COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/im/table/erbi.conf ${CMAKE_CURRENT_BINARY_DIR}/erbi.conf)
 add_custom_command(TARGET copy-im COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/im/table/wbx.conf ${CMAKE_CURRENT_BINARY_DIR}/wbx.conf)
 


### PR DESCRIPTION
testpinyin now relies on shuangpin, need the corresponding conf to load the IM when it is not installed.