### PR TITLE
optimize config for iOS

### DIFF
--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -154,8 +154,8 @@ FCITX_CONFIGURATION(
     Option<bool> z{this, "Z_ZH", _("z <-> zh"), false};
     OptionWithAnnotation<CorrectionLayout, CorrectionLayoutI18NAnnotation>
         correction{this, "Correction", _("Correction Layout"),
-                   isAndroid() ? CorrectionLayout::Qwerty
-                               : CorrectionLayout::None};)
+                   (isAndroid() || isIOS()) ? CorrectionLayout::Qwerty
+                                            : CorrectionLayout::None};)
 
 FCITX_CONFIGURATION(
     PinyinEngineConfig,
@@ -166,7 +166,7 @@ FCITX_CONFIGURATION(
                          ShuangpinProfileEnum::Ziranma};
     OptionWithAnnotation<bool, OptionalHideInDescription> showShuangpinMode{
         this, "ShowShuangpinMode", _("Show current shuangpin mode"), true};
-    Option<int, IntConstrain> pageSize{
+    ConditionalHidden<isIOS(), Option<int, IntConstrain>> pageSize{
         this, "PageSize", _("Candidates Per Page"), 7, IntConstrain(3, 10)};
     Option<bool> spellEnabled{this, "SpellEnabled",
                               _("Show English Candidates"), true};
@@ -177,7 +177,7 @@ FCITX_CONFIGURATION(
     Option<bool> extBEnabled{
         this, "ExtBEnabled",
         _("Enable more Characters after Unicode CJK Extension B"),
-        !isAndroid()};
+        !(isAndroid() || isIOS())};
     Option<bool> strokeCandidateEnabled{
         this, "StrokeCandidateEnabled",
         _("Show stroke candidates when typing with h(一), s(丨), p(丿), n(㇏), "
@@ -209,7 +209,7 @@ FCITX_CONFIGURATION(
     Option<bool> showActualPinyinInPreedit{
         this, "PinyinInPreedit", _("Show complete pinyin in preedit"), false};
     Option<bool> predictionEnabled{this, "Prediction", _("Enable Prediction"),
-                                   isAndroid()};
+                                   isAndroid() || isIOS()};
     OptionWithAnnotation<bool, ToolTipAnnotation> keepCurrentContext{
         this,
         "KeepCurrentContext",

--- a/im/table/engine.h
+++ b/im/table/engine.h
@@ -78,7 +78,7 @@ FCITX_CONFIGURATION(
                          LookupShuangpinProfileEnum::No};
 
     Option<bool> predictionEnabled{this, "Prediction", _("Enable Prediction"),
-                                   isAndroid()};
+                                   isAndroid() || isIOS()};
     Option<int, IntConstrain> predictionSize{this, "PredictionSize",
                                              _("Prediction Size"), 10,
                                              IntConstrain(3, 100)};);

--- a/im/table/ime.h
+++ b/im/table/ime.h
@@ -98,7 +98,8 @@ FCITX_CONFIGURATION(
         {Key(FcitxKey_1), Key(FcitxKey_2), Key(FcitxKey_3), Key(FcitxKey_4),
          Key(FcitxKey_5), Key(FcitxKey_6), Key(FcitxKey_7), Key(FcitxKey_8),
          Key(FcitxKey_9), Key(FcitxKey_0)}};
-    Option<int, IntConstrain, DefaultMarshaller<int>, ToolTipAnnotation>
+    ConditionalHidden<isIOS(), Option<int, IntConstrain, DefaultMarshaller<int>,
+                                      ToolTipAnnotation>>
         pageSize{
             this,
             "PageSize",
@@ -299,7 +300,9 @@ FCITX_CONFIGURATION(
     Option<bool> spaceBeforeHint{
         this, "SpaceBeforeHint",
         _("Show space between candidate and hint text"), true};
-    OptionWithAnnotation<CandidateLayoutHint, CandidateLayoutHintI18NAnnotation>
+    ConditionalHidden<isIOS(),
+                      OptionWithAnnotation<CandidateLayoutHint,
+                                           CandidateLayoutHintI18NAnnotation>>
         candidateLayoutHint{this, "CandidateLayoutHint",
                             _("Candidate List orientation"),
                             CandidateLayoutHint::NotSet};


### PR DESCRIPTION
* ~Force preedit not on beginning, as 3rd-party input method can't have candidate window. See comment for details.~ reverted
* Hide candidate per page and layout hint as there is no candidate window. Candidates are always shown in bulk.
* Turn off Unicode ExtB+.
* Turn on prediction.
* Turn on correction layout.