### PR TITLE
Display full pinyin in comment if it is an duplicate candidate.

### DIFF
--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -618,6 +618,9 @@ void PinyinEngine::updateUI(InputContext *inputContext) {
 
         // Save the middle point for inplace_merge.
         std::vector<std::unique_ptr<PinyinAbstractCandidateWord>> candidates;
+        std::unordered_map<std::string,
+                           std::unordered_set<PinyinCandidateWord *>>
+            candidateSet;
 
         for (size_t idx = 0; idx < pinyinCandidates.size(); ++idx) {
             const auto &candidate = pinyinCandidates[idx];
@@ -634,6 +637,8 @@ void PinyinEngine::updateUI(InputContext *inputContext) {
             auto pinyinCandidate = std::make_unique<PinyinCandidateWord>(
                 this, inputContext, Text(std::move(candidateString)),
                 candidate.sentence().back()->to()->index(), idx, order);
+            candidateSet[pinyinCandidate->text().toString()].insert(
+                pinyinCandidate.get());
             if (iter != customCandidateMap.end()) {
                 if (dynamic_cast<CustomPhraseCandidateWord *>(
                         iter->second.get())) {
@@ -642,6 +647,13 @@ void PinyinEngine::updateUI(InputContext *inputContext) {
                 iter->second = std::move(pinyinCandidate);
             } else {
                 candidates.push_back(std::move(pinyinCandidate));
+            }
+        }
+        for (const auto &[_, candidates] : candidateSet) {
+            if (candidates.size() > 1) {
+                for (auto *candidate : candidates) {
+                    candidate->setPinyinInComment();
+                }
             }
         }
         size_t middle = candidates.size();

--- a/im/pinyin/pinyincandidate.cpp
+++ b/im/pinyin/pinyincandidate.cpp
@@ -22,6 +22,7 @@
 #include <fcitx/inputcontext.h>
 #include <fcitx/text.h>
 #include <fcitx/userinterface.h>
+#include <format>
 #include <libime/core/historybigram.h>
 #include <libime/core/lattice.h>
 #include <libime/pinyin/pinyincontext.h>
@@ -163,7 +164,7 @@ StrokeCandidateWord::StrokeCandidateWord(PinyinEngine *engine, std::string hz,
       hz_(std::move(hz)) {
     setText(Text(hz_));
     if (!py.empty()) {
-        setComment(Text(py));
+        setComment(Text(std::format("({})", py)));
     }
 }
 
@@ -306,6 +307,19 @@ std::string PinyinCandidateWord::customPhraseString() const {
         return text().toString();
     }
     return "";
+}
+
+void PinyinCandidateWord::setPinyinInComment() {
+    auto *state = inputContext_->propertyFor(&engine_->factory());
+    auto &context = state->context_;
+    if (idx_ >= context.candidatesToCursor().size()) {
+        return;
+    }
+    const auto &result = context.candidatesToCursor()[idx_];
+    auto fullPinyin = context.candidateFullPinyin(result);
+    if (!fullPinyin.empty()) {
+        setComment(Text(std::format("({})", fullPinyin)));
+    }
 }
 
 CustomCloudPinyinCandidateWord::CustomCloudPinyinCandidateWord(

--- a/im/pinyin/pinyincandidate.h
+++ b/im/pinyin/pinyincandidate.h
@@ -211,6 +211,8 @@ public:
     bool isCustomPhrase() const override { return isCustomPhrase_; }
     void setCustomPhrase() { isCustomPhrase_ = true; }
 
+    void setPinyinInComment();
+
 private:
     PinyinEngine *engine_;
     InputContext *inputContext_;


### PR DESCRIPTION
Based on recent libime change, if matched pinyin is different, the
candidate will not be dedup'ed. So it's necessary to display the
corresponding full pinyin for the candidate.

Also adjust stroke candidate comment style to be consistent.
