### PR TITLE
split HalfWidthPuncAfterLetterOrNumber

### DIFF
--- a/modules/punctuation/punctuation.cpp
+++ b/modules/punctuation/punctuation.cpp
@@ -64,8 +64,9 @@ std::string langByPath(const std::string &path) {
 class PunctuationState : public InputContextProperty {
 public:
     std::unordered_map<uint32_t, std::string> lastPuncStack_;
-    char lastIsEngOrDigit_ = 0;
     uint32_t notConverted_ = 0;
+    bool lastIsEng_ = false;
+    bool lastIsDigit_ = false;
     bool mayRebuildStateFromSurroundingText_ = false;
 
     std::unordered_map<uint32_t, std::string> lastPuncStackBackup_;
@@ -218,12 +219,14 @@ Punctuation::Punctuation(Instance *instance)
         [this](InputContext *ic, const std::string &sentence) {
             auto *state = ic->propertyFor(&factory_);
             // Though sentence is utf8, we only check ascii.
-            if (!sentence.empty() && (charutils::isupper(sentence.back()) ||
-                                      charutils::islower(sentence.back()) ||
-                                      charutils::isdigit(sentence.back()))) {
-                state->lastIsEngOrDigit_ = sentence.back();
+            if (sentence.empty()) {
+                state->lastIsEng_ = false;
+                state->lastIsDigit_ = false;
             } else {
-                state->lastIsEngOrDigit_ = '\0';
+                auto c = sentence.back();
+                state->lastIsEng_ =
+                    charutils::isupper(c) || charutils::islower(c);
+                state->lastIsDigit_ = charutils::isdigit(c);
             }
         });
     auto processKeyEvent = [this](const KeyEventBase &keyEvent) {
@@ -232,16 +235,9 @@ Punctuation::Punctuation(Instance *instance)
             return;
         }
         if (!keyEvent.accepted()) {
-            if (keyEvent.key().isUAZ() || keyEvent.key().isLAZ() ||
-                keyEvent.key().isDigit() ||
-                (keyEvent.key().sym() >= FcitxKey_KP_0 &&
-                 keyEvent.key().sym() <= FcitxKey_KP_9 &&
-                 !keyEvent.key().hasModifier())) {
-                state->lastIsEngOrDigit_ =
-                    Key::keySymToUnicode(keyEvent.key().sym());
-            } else {
-                state->lastIsEngOrDigit_ = '\0';
-            }
+            state->lastIsEng_ =
+                keyEvent.key().isUAZ() || keyEvent.key().isLAZ();
+            state->lastIsDigit_ = keyEvent.key().isDigit();
         }
     };
     keyEventConn_ =
@@ -290,7 +286,8 @@ Punctuation::Punctuation(Instance *instance)
             auto &icEvent = static_cast<InputContextEvent &>(event);
             auto *ic = icEvent.inputContext();
             auto *state = ic->propertyFor(&factory_);
-            state->lastIsEngOrDigit_ = 0;
+            state->lastIsEng_ = false;
+            state->lastIsDigit_ = false;
             // Backup the state.
             state->notConvertedBackup_ = state->notConverted_;
             state->notConverted_ = 0;
@@ -338,11 +335,10 @@ Punctuation::Punctuation(Instance *instance)
                 return;
             }
             // Need to make sure we have ascii.
-            if (std::distance(start, end) == 1 &&
-                (charutils::isupper(lastCharBeforeCursor) ||
-                 charutils::islower(lastCharBeforeCursor) ||
-                 charutils::isdigit(lastCharBeforeCursor))) {
-                state->lastIsEngOrDigit_ = lastCharBeforeCursor;
+            if (std::distance(start, end) == 1) {
+                state->lastIsEng_ = charutils::isupper(lastCharBeforeCursor) ||
+                                    charutils::islower(lastCharBeforeCursor);
+                state->lastIsDigit_ = charutils::isdigit(lastCharBeforeCursor);
             }
             // Restore the not converted state if we still after the same chr.
             if (lastCharBeforeCursor == state->notConvertedBackup_ &&
@@ -442,10 +438,17 @@ const std::string &Punctuation::pushPunctuation(const std::string &language,
         return emptyString;
     }
     auto *state = ic->propertyFor(&factory_);
-    if (state->lastIsEngOrDigit_ && *config_.halfWidthPuncAfterLatinOrNumber &&
-        dontConvertWhenEn(unicode)) {
-        state->notConverted_ = unicode;
-        return emptyString;
+    if (dontConvertWhenEn(unicode)) {
+        auto type = *config_.halfWidthPuncAfterType;
+        if ((state->lastIsDigit_ &&
+             (type == HalfWidthPuncAfterType::Number ||
+              type == HalfWidthPuncAfterType::LatinOrNumber)) ||
+            (state->lastIsEng_ &&
+             (type == HalfWidthPuncAfterType::Latin ||
+              type == HalfWidthPuncAfterType::LatinOrNumber))) {
+            state->notConverted_ = unicode;
+            return emptyString;
+        }
     }
     auto iter = profiles_.find(language);
     if (iter == profiles_.end()) {
@@ -473,10 +476,17 @@ Punctuation::pushPunctuationV2(const std::string &language, InputContext *ic,
         return {emptyString, emptyString};
     }
     auto *state = ic->propertyFor(&factory_);
-    if (state->lastIsEngOrDigit_ && *config_.halfWidthPuncAfterLatinOrNumber &&
-        dontConvertWhenEn(unicode)) {
-        state->notConverted_ = unicode;
-        return {emptyString, emptyString};
+    if (dontConvertWhenEn(unicode)) {
+        auto type = *config_.halfWidthPuncAfterType;
+        if ((state->lastIsDigit_ &&
+             (type == HalfWidthPuncAfterType::Number ||
+              type == HalfWidthPuncAfterType::LatinOrNumber)) ||
+            (state->lastIsEng_ &&
+             (type == HalfWidthPuncAfterType::Latin ||
+              type == HalfWidthPuncAfterType::LatinOrNumber))) {
+            state->notConverted_ = unicode;
+            return {emptyString, emptyString};
+        }
     }
     auto iter = profiles_.find(language);
     if (iter == profiles_.end()) {

--- a/modules/punctuation/punctuation.h
+++ b/modules/punctuation/punctuation.h
@@ -33,13 +33,19 @@
 #include <utility>
 #include <vector>
 
+enum class HalfWidthPuncAfterType { None, Latin, Number, LatinOrNumber };
+
+FCITX_CONFIG_ENUM_NAME_WITH_I18N(HalfWidthPuncAfterType, N_("None"),
+                                 N_("Latin"), N_("Number"),
+                                 N_("Latin or Number"))
+
 FCITX_CONFIGURATION(
     PunctuationConfig,
     fcitx::Option<fcitx::KeyList> hotkey{
         this, "Hotkey", _("Toggle key"), {fcitx::Key("Control+period")}};
-    fcitx::Option<bool> halfWidthPuncAfterLatinOrNumber{
-        this, "HalfWidthPuncAfterLetterOrNumber",
-        _("Half width punctuation after latin letter or number"), true};
+    fcitx::Option<HalfWidthPuncAfterType> halfWidthPuncAfterType{
+        this, "HalfWidthPuncAfterType", _("Use half width punctuation after"),
+        HalfWidthPuncAfterType::LatinOrNumber};
     fcitx::Option<bool> typePairedPunctuationTogether{
         this, "TypePairedPunctuationsTogether",
         _("Type paired punctuations together (e.g. Quote)"), false};


### PR DESCRIPTION
Closes #274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new punctuation behavior configuration that can independently control half-width punctuation handling after Latin letters and after numbers (including a combined option).
* **Bug Fixes**
  * Improved punctuation conversion context detection so punctuation behavior stays consistent when switching between alphabetic and numeric input.
* **Documentation**
  * Updated the punctuation setting name and options to match the new “after type” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->