### PR TITLE
Skip separator when building tab and try to optimize performance of bestMatchPinyin by only return syallable at the end.

### DIFF
--- a/im/pinyin/pinyincandidate.cpp
+++ b/im/pinyin/pinyincandidate.cpp
@@ -9,6 +9,7 @@
 #include "../../modules/cloudpinyin/cloudpinyin_public.h"
 #include "pinyin.h"
 #include <algorithm>
+#include <boost/container_hash/hash.hpp>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -37,6 +38,7 @@
 #include <string>
 #include <string_view>
 #include <tuple>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -44,11 +46,40 @@ namespace fcitx {
 
 namespace {
 
-// Helper function to produce the full pinyin string that matches the best to
+using PinyinCacheKey = std::tuple<std::string, std::string>;
+using PinyinCacheLookupKey = std::tuple<std::string_view, std::string_view>;
+
+struct PinyinCacheKeyHash {
+    using is_transparent = void;
+
+    size_t operator()(PinyinCacheLookupKey key) const noexcept {
+        const auto &[pinyin, candidatePinyin] = key;
+        size_t seed = 0;
+        boost::hash_combine(seed, pinyin);
+        boost::hash_combine(seed, candidatePinyin);
+        return seed;
+    }
+};
+
+using PinyinCache =
+    std::unordered_map<PinyinCacheKey, std::optional<libime::PinyinSyllable>,
+                       PinyinCacheKeyHash, std::equal_to<>>;
+
+// Helper function to produce the pinyin that matches the best to
 // the encoded candidate pinyin.
 std::optional<libime::PinyinSyllable>
-bestMatchPinyin(std::string_view pinyin, const std::string &candidatePinyin,
-                libime::PinyinContext &context) {
+bestMatchPinyin(std::string_view pinyin, std::string_view candidatePinyin,
+                const libime::PinyinContext &context, PinyinCache &cache) {
+    if (candidatePinyin.size() < 2) {
+        return std::nullopt;
+    }
+
+    // Cache hit rate should be very high since there could be only few pinyin
+    // matches, so we can use the cache to avoid repeated computation.
+    if (auto it = cache.find(PinyinCacheLookupKey{pinyin, candidatePinyin});
+        it != cache.end()) {
+        return it->second;
+    }
 
     libime::MatchedPinyinSyllablesWithFuzzyFlags syls;
     syls = context.useShuangpin()
@@ -60,8 +91,7 @@ bestMatchPinyin(std::string_view pinyin, const std::string &candidatePinyin,
                      context.ime()->fuzzyFlags());
     std::optional<libime::PinyinSyllable> syl;
 
-    if (!syls.empty() && !syls.front().second.empty() &&
-        candidatePinyin.size() >= 2) {
+    if (!syls.empty() && !syls.front().second.empty()) {
         auto candidateInitial =
             static_cast<libime::PinyinInitial>(candidatePinyin[0]);
         auto candidateFinal =
@@ -78,6 +108,9 @@ bestMatchPinyin(std::string_view pinyin, const std::string &candidatePinyin,
             }
         }
     }
+
+    cache.try_emplace(
+        PinyinCacheKey{std::string(pinyin), std::string(candidatePinyin)}, syl);
 
     return syl;
 }
@@ -483,6 +516,8 @@ void PinyinTabbedCandidateList::buildTabActions() {
         return;
     }
 
+    PinyinCache cache;
+
     for (size_t i = 0; i < candidateList_->originSize(); i++) {
         const auto *candidate = &candidateList_->originCandidate(i);
         const auto *pinyinCandidate =
@@ -519,8 +554,10 @@ void PinyinTabbedCandidateList::buildTabActions() {
         }
         auto actualPinyin = bestMatchPinyin(
             syllable,
-            sentence[0]->as<libime::PinyinLatticeNode>().encodedPinyin(),
-            context);
+            std::string_view(
+                sentence[0]->as<libime::PinyinLatticeNode>().encodedPinyin())
+                .substr(0, 2),
+            context, cache);
 
         auto it = syllableToId.find(std::tuple{syllable, actualPinyin});
         if (it == syllableToId.end()) {

--- a/im/pinyin/pinyincandidate.cpp
+++ b/im/pinyin/pinyincandidate.cpp
@@ -23,6 +23,7 @@
 #include <fcitx/text.h>
 #include <fcitx/userinterface.h>
 #include <format>
+#include <functional>
 #include <libime/core/historybigram.h>
 #include <libime/core/lattice.h>
 #include <libime/pinyin/pinyincontext.h>
@@ -34,6 +35,7 @@
 #include <optional>
 #include <span>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -44,9 +46,9 @@ namespace {
 
 // Helper function to produce the full pinyin string that matches the best to
 // the encoded candidate pinyin.
-std::string bestMatchPinyin(const std::string &pinyin,
-                            const std::string &candidatePinyin,
-                            libime::PinyinContext &context) {
+std::optional<libime::PinyinSyllable>
+bestMatchPinyin(std::string_view pinyin, const std::string &candidatePinyin,
+                libime::PinyinContext &context) {
 
     libime::MatchedPinyinSyllablesWithFuzzyFlags syls;
     syls = context.useShuangpin()
@@ -56,7 +58,6 @@ std::string bestMatchPinyin(const std::string &pinyin,
                : libime::PinyinEncoder::stringToSyllablesWithFuzzyFlags(
                      pinyin, context.ime()->correctionProfile().get(),
                      context.ime()->fuzzyFlags());
-    std::string actualPinyin;
     std::optional<libime::PinyinSyllable> syl;
 
     if (!syls.empty() && !syls.front().second.empty() &&
@@ -78,13 +79,7 @@ std::string bestMatchPinyin(const std::string &pinyin,
         }
     }
 
-    if (syl) {
-        actualPinyin = libime::PinyinEncoder::initialFinalToPinyinString(
-            syl->initial(), syl->final());
-    } else {
-        actualPinyin = pinyin;
-    }
-    return actualPinyin;
+    return syl;
 }
 
 bool isSinglePinyin(const libime::PinyinContext &context, size_t idx) {
@@ -477,9 +472,11 @@ void PinyinTabbedCandidateList::buildTabActions() {
     auto *state = inputContext_->propertyFor(&engine_->factory());
     auto &context = state->context_;
     auto selectedLen = context.selectedLength();
-    const auto &fullInput = context.userInput();
+    std::string_view fullInput = context.userInput();
 
-    std::map<std::tuple<std::string, std::string>, int> syllableToId;
+    std::map<std::tuple<std::string, std::optional<libime::PinyinSyllable>>,
+             int, std::less<>>
+        syllableToId;
 
     if (!candidateList_) {
         actions_ = std::move(actions);
@@ -507,21 +504,37 @@ void PinyinTabbedCandidateList::buildTabActions() {
         if (path.size() < 2) {
             continue;
         }
-        auto start = selectedLen + path[0]->index();
-        auto end = selectedLen + path[1]->index();
-
-        auto syllable = fullInput.substr(start, end - start);
+        std::string_view syllable;
+        for (size_t i = 1; i < path.size(); i++) {
+            auto start = selectedLen + path[i - 1]->index();
+            auto n = path[i]->index() - path[i - 1]->index();
+            auto segment = fullInput.substr(start, n);
+            if (!segment.starts_with('\'')) {
+                syllable = segment;
+                break;
+            }
+        }
+        if (syllable.empty()) {
+            continue;
+        }
         auto actualPinyin = bestMatchPinyin(
             syllable,
             sentence[0]->as<libime::PinyinLatticeNode>().encodedPinyin(),
             context);
 
-        auto [it, inserted] = syllableToId.emplace(
-            std::tuple{syllable, actualPinyin}, actions.size());
-        if (inserted) {
+        auto it = syllableToId.find(std::tuple{syllable, actualPinyin});
+        if (it == syllableToId.end()) {
+            it = syllableToId
+                     .emplace(std::make_tuple(syllable, actualPinyin),
+                              actions.size())
+                     .first;
             CandidateAction action;
             action.setId(actions.size());
-            action.setText(actualPinyin);
+            action.setText(
+                actualPinyin
+                    ? libime::PinyinEncoder::initialFinalToPinyinString(
+                          actualPinyin->initial(), actualPinyin->final())
+                    : std::string(syllable));
             action.setCheckable(true);
             action.setChecked(checkedPinyinActionId_ == action.id());
             actions.push_back(std::move(action));

--- a/test/testpinyin.cpp
+++ b/test/testpinyin.cpp
@@ -411,6 +411,32 @@ void testPinyinTabFilter(Instance *instance) {
     });
 }
 
+void testPinyinTabFilterWithSeparator(Instance *instance) {
+    instance->eventDispatcher().schedule([instance]() {
+        auto *pinyin = instance->addonManager().addon("pinyin");
+        FCITX_ASSERT(pinyin);
+        auto *testfrontend = instance->addonManager().addon("testfrontend");
+        auto uuid =
+            testfrontend->call<ITestFrontend::createInputContext>("testapp");
+        auto *ic = instance->inputContextManager().findByUUID(uuid);
+        FCITX_ASSERT(ic);
+        instance->setCurrentInputMethod(ic, "pinyin", true);
+        testfrontend->call<ITestFrontend::keyEvent>(uuid, Key("x"), false);
+        testfrontend->call<ITestFrontend::keyEvent>(uuid, Key("i"), false);
+        testfrontend->call<ITestFrontend::keyEvent>(uuid, Key("'"), false);
+        testfrontend->call<ITestFrontend::keyEvent>(uuid, Key("'"), false);
+        testfrontend->call<ITestFrontend::keyEvent>(uuid, Key("a"), false);
+        testfrontend->call<ITestFrontend::keyEvent>(uuid, Key("n"), false);
+        findAndSelectCandidate(ic, "西");
+        auto *tabbed = ic->inputPanel().candidateList()->toTabbed();
+        FCITX_ASSERT(tabbed);
+        auto actionSpan = tabbed->tabActions();
+        FCITX_ASSERT(std::ranges::none_of(actionSpan, [](const auto &a) {
+            return a.text().starts_with('\'');
+        }));
+    });
+}
+
 void testPin(Instance *instance) {
     instance->eventDispatcher().schedule([instance]() {
         auto *testfrontend = instance->addonManager().addon("testfrontend");
@@ -649,6 +675,7 @@ int main() {
     testForget(&instance);
     testActionInStrokeFilter(&instance);
     testPinyinTabFilter(&instance);
+    testPinyinTabFilterWithSeparator(&instance);
     testPin(&instance);
     testQuickPhraseTrigger(&instance);
     testVQuickPhraseTrigger(&instance);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pinyin candidate matching for inputs containing apostrophe separators.
  * Tab completion now selects the correct syllable and hides entries beginning with apostrophes.
  * Completion labels use normalized Pinyin when available, or preserve the original input when needed.
  * Inputs without a matching candidate are handled more accurately.
* **Tests**
  * Added coverage for separator-containing Pinyin input, including selection of the expected Chinese character and filtering of apostrophe-prefixed entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->