### PR TITLE
Add aux code support for pinyin

### DIFF
--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -430,6 +430,9 @@ void PinyinEngine::updateUI(InputContext *inputContext) {
     if (state->mode_ == PinyinMode::StrokeFilter) {
         resetStroke(inputContext);
     }
+    if (state->mode_ == PinyinMode::AuxCodeFilter) {
+        resetAuxCode(inputContext);
+    }
     inputContext->inputPanel().reset();
     // Use const ref to avoid accidentally change anything.
     const auto &context = state->context_;
@@ -1508,6 +1511,9 @@ void PinyinEngine::updateFilter(InputContext *inputContext) {
         aux.append(_("[Stroke Filtering]"));
         aux.append(pinyinhelper()->call<IPinyinHelper::prettyStrokeString>(
             state->strokeBuffer_.userInput()));
+    } else if (state->mode_ == PinyinMode::AuxCodeFilter) {
+        aux.append(_("[Aux Code Filtering]"));
+        aux.append(state->auxCodeBuffer_.userInput());
     }
     inputPanel.setAuxUp(aux);
     inputPanel.setAuxDown(Text());
@@ -1517,7 +1523,7 @@ void PinyinEngine::updateFilter(InputContext *inputContext) {
     if (candidateList) {
         auto *pinyinTabbed = dynamic_cast<PinyinTabbedCandidateList *>(
             candidateList->toTabbed());
-        if (state->strokeBuffer_.empty() &&
+        if ((state->strokeBuffer_.empty() && state->auxCodeBuffer_.empty()) &&
             (!pinyinTabbed || !pinyinTabbed->checked())) {
             candidateList->clearFilter();
         } else {
@@ -1552,6 +1558,11 @@ void PinyinEngine::updateFilter(InputContext *inputContext) {
                         }
                     }
                     return false;
+                }
+                if (!state->auxCodeBuffer_.empty()) {
+                    auto str = candidate.text().toStringForCommit();
+                    return pinyinhelper()->call<IPinyinHelper::matchAuxCode>(
+                        str, state->auxCodeBuffer_.userInput());
                 }
                 return true;
             });
@@ -1610,6 +1621,14 @@ void PinyinEngine::resetStroke(InputContext *inputContext) const {
     auto *state = inputContext->propertyFor(&factory_);
     state->strokeBuffer_.clear();
     if (state->mode_ == PinyinMode::StrokeFilter) {
+        state->mode_ = PinyinMode::Normal;
+    }
+}
+
+void PinyinEngine::resetAuxCode(InputContext *inputContext) const {
+    auto *state = inputContext->propertyFor(&factory_);
+    state->auxCodeBuffer_.clear();
+    if (state->mode_ == PinyinMode::AuxCodeFilter) {
         state->mode_ = PinyinMode::Normal;
     }
 }
@@ -1781,6 +1800,70 @@ bool PinyinEngine::handleStrokeFilter(
             state->strokeBuffer_.type(iter->second);
             updateFilter(inputContext);
         }
+    }
+
+    return true;
+}
+
+bool PinyinEngine::handleAuxCodeFilter(
+    KeyEvent &event, const std::shared_future<uint32_t> &keyChr) {
+    auto *inputContext = event.inputContext();
+    auto candidateList = inputContext->inputPanel().candidateList();
+    auto *state = inputContext->propertyFor(&factory_);
+    if (state->mode_ == PinyinMode::Normal) {
+        if (candidateList && !candidateList->empty() &&
+            candidateList->toBulk() && !config_.auxCodeTable->empty() &&
+            event.key().check(*config_.auxCodeTriggerKey) && pinyinhelper()) {
+            pinyinhelper()->call<IPinyinHelper::loadAuxCode>(
+                *config_.auxCodeTable);
+            resetAuxCode(inputContext);
+            state->mode_ = PinyinMode::AuxCodeFilter;
+            updateFilter(inputContext);
+
+            event.filterAndAccept();
+            return true;
+        }
+        return false;
+    }
+
+    if (state->mode_ != PinyinMode::AuxCodeFilter) {
+        return false;
+    }
+
+    event.filterAndAccept();
+
+    if (handleCandidateList(event, keyChr)) {
+        return true;
+    }
+    // Skip all key combination.
+    if (event.key().states().testAny(KeyState::SimpleMask)) {
+        return true;
+    }
+
+    if (event.key().check(FcitxKey_Escape)) {
+        resetAuxCode(inputContext);
+        updateUI(inputContext);
+        return true;
+    }
+    if (event.key().check(FcitxKey_BackSpace)) {
+        if (!state->auxCodeBuffer_.empty()) {
+            state->auxCodeBuffer_.backspace();
+            updateFilter(inputContext);
+        } else {
+            resetAuxCode(inputContext);
+            updateUI(inputContext);
+        }
+        return true;
+    }
+    // if it gonna commit something
+    auto c = keyChr.get();
+    if (!c) {
+        return true;
+    }
+
+    if (event.key().isLAZ() || event.key().isUAZ()) {
+        state->auxCodeBuffer_.type(Key::keySymToUTF8(event.key().sym()));
+        updateFilter(inputContext);
     }
 
     return true;
@@ -2040,6 +2123,10 @@ void PinyinEngine::keyEvent(const InputMethodEntry &entry, KeyEvent &event) {
     state->lastIsPunc_ = false;
 
     if (handleStrokeFilter(event, keyChr)) {
+        return;
+    }
+
+    if (handleAuxCodeFilter(event, keyChr)) {
         return;
     }
 

--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -1837,6 +1837,17 @@ bool PinyinEngine::handleAuxCodeFilter(
     }
 
     event.filterAndAccept();
+    // Allow prev page to quit aux code filtering.
+    if ((state->auxCodeBuffer_.empty() &&
+         event.key().checkKeyList(*config_.prevPage))) {
+        auto candidateList = inputContext->inputPanel().candidateList();
+        if (candidateList && candidateList->toPageable() &&
+            candidateList->toPageable()->currentPage() <= 1) {
+            resetAuxCode(inputContext);
+            updateUI(inputContext);
+            return true;
+        }
+    }
 
     if (handleCandidateList(event, keyChr)) {
         return true;

--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -1825,6 +1825,7 @@ bool PinyinEngine::handleAuxCodeFilter(
             resetAuxCode(inputContext);
             state->mode_ = PinyinMode::AuxCodeFilter;
             updateFilter(inputContext);
+            handleNextPage(event);
 
             event.filterAndAccept();
             return true;

--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -430,13 +430,13 @@ void PinyinEngine::updateUI(InputContext *inputContext) {
     if (state->mode_ == PinyinMode::StrokeFilter) {
         resetStroke(inputContext);
     }
-    if (state->mode_ == PinyinMode::AuxCodeFilter) {
-        resetAuxCode(inputContext);
-    }
     inputContext->inputPanel().reset();
     // Use const ref to avoid accidentally change anything.
     const auto &context = state->context_;
     if (context.selected()) {
+        if (state->mode_ == PinyinMode::AuxCodeFilter) {
+            resetAuxCode(inputContext);
+        }
         auto sentence = context.sentence();
         if (!inputContext->capabilityFlags().testAny(
                 CapabilityFlag::PasswordOrSensitive)) {
@@ -452,6 +452,9 @@ void PinyinEngine::updateUI(InputContext *inputContext) {
 
     do {
         if (context.userInput().empty()) {
+            if (state->mode_ == PinyinMode::AuxCodeFilter) {
+                resetAuxCode(inputContext);
+            }
             break;
         }
         // Update Preedit.
@@ -731,6 +734,14 @@ void PinyinEngine::updateUI(InputContext *inputContext) {
     } while (0);
     inputContext->updatePreedit();
     inputContext->updateUserInterface(UserInterfaceComponent::InputPanel);
+
+    // After partial candidate selection, clear the old aux code buffer but
+    // keep the mode, so the user can type new codes to filter the remaining
+    // pinyin without re-entering aux code mode.
+    if (state->mode_ == PinyinMode::AuxCodeFilter) {
+        state->auxCodeBuffer_.clear();
+        updateFilter(inputContext);
+    }
 }
 
 std::string PinyinEngine::evaluateCustomPhrase(InputContext *inputContext,

--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -1827,14 +1827,8 @@ bool PinyinEngine::handleAuxCodeFilter(
             !config_.filterByAuxCode->profile->empty() &&
             event.key().check(*config_.filterByAuxCode->triggerKey) &&
             pinyinhelper()) {
-            auto auxPath = stringutils::concat(
-                "pinyin/auxcode/", *config_.filterByAuxCode->profile);
-            auto located = StandardPaths::global().locate(
-                StandardPathsType::PkgData, auxPath);
-            if (!located.empty()) {
-                pinyinhelper()->call<IPinyinHelper::loadAuxCode>(
-                    located.string());
-            }
+            pinyinhelper()->call<IPinyinHelper::loadAuxCode>(
+                *config_.filterByAuxCode->profile);
             resetAuxCode(inputContext);
             state->mode_ = PinyinMode::AuxCodeFilter;
             updateFilter(inputContext);
@@ -1893,7 +1887,7 @@ bool PinyinEngine::handleAuxCodeFilter(
     }
 
     if (event.key().isLAZ() || event.key().isUAZ()) {
-        state->auxCodeBuffer_.type(Key::keySymToUTF8(event.key().sym()));
+        state->auxCodeBuffer_.type(utf8::UCS4ToUTF8(c));
         updateFilter(inputContext);
     }
 
@@ -2446,6 +2440,7 @@ void PinyinEngine::reset(const InputMethodEntry & /*entry*/,
 void PinyinEngine::doReset(InputContext *inputContext) const {
     auto *state = inputContext->propertyFor(&factory_);
     resetStroke(inputContext);
+    resetAuxCode(inputContext);
     resetForgetCandidate(inputContext);
     state->mode_ = PinyinMode::Normal;
     state->context_.clear();

--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -1812,10 +1812,16 @@ bool PinyinEngine::handleAuxCodeFilter(
     auto *state = inputContext->propertyFor(&factory_);
     if (state->mode_ == PinyinMode::Normal) {
         if (candidateList && !candidateList->empty() &&
-            candidateList->toBulk() && !config_.auxCodeTable->empty() &&
+            candidateList->toBulk() && !config_.auxCodeProfile->empty() &&
             event.key().check(*config_.auxCodeTriggerKey) && pinyinhelper()) {
-            pinyinhelper()->call<IPinyinHelper::loadAuxCode>(
-                *config_.auxCodeTable);
+            auto auxPath = stringutils::concat("pinyin/auxcode/",
+                                               *config_.auxCodeProfile);
+            auto located = StandardPaths::global().locate(
+                StandardPathsType::PkgData, auxPath);
+            if (!located.empty()) {
+                pinyinhelper()->call<IPinyinHelper::loadAuxCode>(
+                    located.string());
+            }
             resetAuxCode(inputContext);
             state->mode_ = PinyinMode::AuxCodeFilter;
             updateFilter(inputContext);

--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -1812,10 +1812,12 @@ bool PinyinEngine::handleAuxCodeFilter(
     auto *state = inputContext->propertyFor(&factory_);
     if (state->mode_ == PinyinMode::Normal) {
         if (candidateList && !candidateList->empty() &&
-            candidateList->toBulk() && !config_.auxCodeProfile->empty() &&
-            event.key().check(*config_.auxCodeTriggerKey) && pinyinhelper()) {
-            auto auxPath = stringutils::concat("pinyin/auxcode/",
-                                               *config_.auxCodeProfile);
+            candidateList->toBulk() &&
+            !config_.filterByAuxCode->profile->empty() &&
+            event.key().check(*config_.filterByAuxCode->triggerKey) &&
+            pinyinhelper()) {
+            auto auxPath = stringutils::concat(
+                "pinyin/auxcode/", *config_.filterByAuxCode->profile);
             auto located = StandardPaths::global().locate(
                 StandardPathsType::PkgData, auxPath);
             if (!located.empty()) {

--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -1824,11 +1824,11 @@ bool PinyinEngine::handleAuxCodeFilter(
     if (state->mode_ == PinyinMode::Normal) {
         if (candidateList && !candidateList->empty() &&
             candidateList->toBulk() &&
-            !config_.filterByAuxCode->profile->empty() &&
-            event.key().check(*config_.filterByAuxCode->triggerKey) &&
+            !config_.auxCodeProfile->empty() &&
+            event.key().check(*config_.auxCodeTriggerKey) &&
             pinyinhelper()) {
             pinyinhelper()->call<IPinyinHelper::loadAuxCode>(
-                *config_.filterByAuxCode->profile);
+                *config_.auxCodeProfile);
             resetAuxCode(inputContext);
             state->mode_ = PinyinMode::AuxCodeFilter;
             updateFilter(inputContext);

--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -161,6 +161,16 @@ FCITX_CONFIGURATION(
                                             : CorrectionLayout::None};)
 
 FCITX_CONFIGURATION(
+    AuxCodeConfig,
+    Option<std::string> profile{this, "Profile", _("Aux Code Profile"), ""};
+    Option<Key, KeyConstrain> triggerKey{
+        this,
+        "TriggerKey",
+        _("Key to trigger aux code mode"),
+        Key(),
+        {KeyConstrainFlag::AllowModifierLess}};)
+
+FCITX_CONFIGURATION(
     PinyinEngineConfig,
     OptionWithAnnotation<
         ShuangpinProfileEnum,
@@ -319,14 +329,8 @@ FCITX_CONFIGURATION(
         _("Filter by stroke"),
         {Key("grave")},
         KeyListConstrain({KeyConstrainFlag::AllowModifierLess})};
-    Option<std::string> auxCodeProfile{
-        this, "AuxCodeProfile", _("Aux Code Profile"), ""};
-    Option<Key, KeyConstrain> auxCodeTriggerKey{
-        this,
-        "AuxCodeTriggerKey",
-        _("Key to trigger aux code mode"),
-        Key(),
-        {KeyConstrainFlag::AllowModifierLess}};
+    Option<AuxCodeConfig> filterByAuxCode{
+        this, "FilterByAuxCode", _("Filter by Aux Code")};
     Option<int, IntConstrain> nbest{this, "Number of sentence",
                                     _("Number of Sentences"), 2,
                                     IntConstrain(1, 3)};

--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -319,8 +319,8 @@ FCITX_CONFIGURATION(
         _("Filter by stroke"),
         {Key("grave")},
         KeyListConstrain({KeyConstrainFlag::AllowModifierLess})};
-    Option<std::string> auxCodeTable{
-        this, "AuxCodeTable", _("Aux Code Table Path"), ""};
+    Option<std::string> auxCodeProfile{
+        this, "AuxCodeProfile", _("Aux Code Profile"), ""};
     Option<Key, KeyConstrain> auxCodeTriggerKey{
         this,
         "AuxCodeTriggerKey",

--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -319,6 +319,14 @@ FCITX_CONFIGURATION(
         _("Filter by stroke"),
         {Key("grave")},
         KeyListConstrain({KeyConstrainFlag::AllowModifierLess})};
+    Option<std::string> auxCodeTable{
+        this, "AuxCodeTable", _("Aux Code Table Path"), ""};
+    Option<Key, KeyConstrain> auxCodeTriggerKey{
+        this,
+        "AuxCodeTriggerKey",
+        _("Key to trigger aux code mode"),
+        Key(),
+        {KeyConstrainFlag::AllowModifierLess}};
     Option<int, IntConstrain> nbest{this, "Number of sentence",
                                     _("Number of Sentences"), 2,
                                     IntConstrain(1, 3)};
@@ -373,7 +381,7 @@ struct EventSourceTime;
 class CandidateList;
 class PinyinEngine;
 
-enum class PinyinMode { Normal, StrokeFilter, ForgetCandidate, Punctuation };
+enum class PinyinMode { Normal, StrokeFilter, AuxCodeFilter, ForgetCandidate, Punctuation };
 
 class PinyinState : public InputContextProperty {
 public:
@@ -386,6 +394,9 @@ public:
 
     // Stroke filter
     InputBuffer strokeBuffer_;
+
+    // Aux code filter
+    InputBuffer auxCodeBuffer_;
 
     // Forget candidate
     std::shared_ptr<CandidateList> forgetCandidateList_;
@@ -445,6 +456,7 @@ public:
     void updateFilter(InputContext *inputContext);
 
     void resetStroke(InputContext *inputContext) const;
+    void resetAuxCode(InputContext *inputContext) const;
     void resetForgetCandidate(InputContext *inputContext) const;
     void forgetCandidate(InputContext *inputContext, size_t index);
     void pinCustomPhrase(InputContext *inputContext,
@@ -468,6 +480,8 @@ private:
     bool handleNextPage(KeyEvent &event) const;
     bool handleStrokeFilter(KeyEvent &event,
                             const std::shared_future<uint32_t> &keyChr);
+    bool handleAuxCodeFilter(KeyEvent &event,
+                             const std::shared_future<uint32_t> &keyChr);
     bool handleForgetCandidate(KeyEvent &event);
     bool handlePunc(KeyEvent &event,
                     const std::shared_future<uint32_t> &keyChr);

--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -161,16 +161,6 @@ FCITX_CONFIGURATION(
                                             : CorrectionLayout::None};)
 
 FCITX_CONFIGURATION(
-    AuxCodeConfig,
-    Option<std::string> profile{this, "Profile", _("Aux Code Profile"), ""};
-    Option<Key, KeyConstrain> triggerKey{
-        this,
-        "TriggerKey",
-        _("Key to trigger aux code mode"),
-        Key(),
-        {KeyConstrainFlag::AllowModifierLess}};)
-
-FCITX_CONFIGURATION(
     PinyinEngineConfig,
     OptionWithAnnotation<
         ShuangpinProfileEnum,
@@ -329,8 +319,14 @@ FCITX_CONFIGURATION(
         _("Filter by stroke"),
         {Key("grave")},
         KeyListConstrain({KeyConstrainFlag::AllowModifierLess})};
-    Option<AuxCodeConfig> filterByAuxCode{
-        this, "FilterByAuxCode", _("Filter by Aux Code")};
+    Option<std::string> auxCodeProfile{
+        this, "AuxCodeProfile", _("Aux Code Profile"), ""};
+    Option<Key, KeyConstrain> auxCodeTriggerKey{
+        this,
+        "AuxCodeTriggerKey",
+        _("Key to trigger aux code mode"),
+        Key(),
+        {KeyConstrainFlag::AllowModifierLess}};
     Option<int, IntConstrain> nbest{this, "Number of sentence",
                                     _("Number of Sentences"), 2,
                                     IntConstrain(1, 3)};

--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -399,8 +399,8 @@ public:
     // Stroke filter
     InputBuffer strokeBuffer_;
 
-    // Aux code filter
-    InputBuffer auxCodeBuffer_;
+    // Aux code filter (ASCII only)
+    InputBuffer auxCodeBuffer_{InputBufferOption::AsciiOnly};
 
     // Forget candidate
     std::shared_ptr<CandidateList> forgetCandidateList_;

--- a/modules/pinyinhelper/CMakeLists.txt
+++ b/modules/pinyinhelper/CMakeLists.txt
@@ -2,6 +2,7 @@ set(PINYINHELPER_SOURCES
     pinyinhelper.cpp
     pinyinlookup.cpp
     stroke.cpp
+    auxcode.cpp
 )
 add_fcitx5_addon(pinyinhelper ${PINYINHELPER_SOURCES})
 target_link_libraries(pinyinhelper 

--- a/modules/pinyinhelper/auxcode.cpp
+++ b/modules/pinyinhelper/auxcode.cpp
@@ -6,6 +6,7 @@
  */
 #include "auxcode.h"
 
+#include <fcitx-utils/fdstreambuf.h>
 #include <fcitx-utils/stringutils.h>
 #include <fcitx-utils/utf8.h>
 #include <fstream>
@@ -20,9 +21,23 @@ void AuxCode::loadFromFile(const std::string &path) {
     if (!file.is_open()) {
         return;
     }
+    parseStream(file);
+    loaded_ = true;
+}
 
+void AuxCode::loadFromFD(int fd) {
+    table_.clear();
+    loaded_ = false;
+
+    IFDStreamBuf buffer(fd);
+    std::istream in(&buffer);
+    parseStream(in);
+    loaded_ = true;
+}
+
+void AuxCode::parseStream(std::istream &in) {
     std::string buf;
-    while (std::getline(file, buf)) {
+    while (std::getline(in, buf)) {
         if (!utf8::validate(buf)) {
             continue;
         }
@@ -44,8 +59,6 @@ void AuxCode::loadFromFile(const std::string &path) {
         }
         table_[std::string(character)].push_back(std::string(code));
     }
-
-    loaded_ = true;
 }
 
 std::string AuxCode::getFirstCode(const std::string &character) const {

--- a/modules/pinyinhelper/auxcode.cpp
+++ b/modules/pinyinhelper/auxcode.cpp
@@ -66,6 +66,26 @@ bool AuxCode::matchPhrase(const std::string &phrase,
 
     size_t inputLen = auxInput.size();
 
+    // Single character: check if any code starts with input
+    if (charCount == 1) {
+        std::string chr;
+        for (auto iter = std::begin(charRange); iter != std::end(charRange);
+             ++iter) {
+            chr.assign(iter.charRange().first, iter.charRange().second);
+        }
+        auto it = table_.find(chr);
+        if (it == table_.end()) {
+            return false;
+        }
+        for (const auto &code : it->second) {
+            if (code.starts_with(auxInput)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Phrase: input length must not exceed char count
     if (inputLen > static_cast<size_t>(charCount)) {
         return false;
     }

--- a/modules/pinyinhelper/auxcode.cpp
+++ b/modules/pinyinhelper/auxcode.cpp
@@ -7,11 +7,30 @@
 #include "auxcode.h"
 
 #include <fcitx-utils/fdstreambuf.h>
+#include <fcitx-utils/standardpaths.h>
 #include <fcitx-utils/stringutils.h>
 #include <fcitx-utils/utf8.h>
 #include <fstream>
 
 namespace fcitx {
+
+void AuxCode::loadProfile(const std::string &profile) {
+    if (profile == loadedProfile_ && loaded_) {
+        return;
+    }
+    auto path = stringutils::concat("pinyin/auxcode/", profile);
+    auto file = StandardPaths::global().open(StandardPathsType::PkgData, path);
+    if (!file.isValid()) {
+        return;
+    }
+    table_.clear();
+    loaded_ = false;
+    IFDStreamBuf buffer(file.fd());
+    std::istream in(&buffer);
+    parseStream(in);
+    loaded_ = true;
+    loadedProfile_ = profile;
+}
 
 void AuxCode::loadFromFile(const std::string &path) {
     table_.clear();
@@ -22,16 +41,6 @@ void AuxCode::loadFromFile(const std::string &path) {
         return;
     }
     parseStream(file);
-    loaded_ = true;
-}
-
-void AuxCode::loadFromFD(int fd) {
-    table_.clear();
-    loaded_ = false;
-
-    IFDStreamBuf buffer(fd);
-    std::istream in(&buffer);
-    parseStream(in);
     loaded_ = true;
 }
 

--- a/modules/pinyinhelper/auxcode.cpp
+++ b/modules/pinyinhelper/auxcode.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024
+ * SPDX-FileCopyrightText: 2026
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
@@ -8,7 +8,6 @@
 
 #include <fcitx-utils/utf8.h>
 #include <fstream>
-#include <string_view>
 
 namespace fcitx {
 

--- a/modules/pinyinhelper/auxcode.cpp
+++ b/modules/pinyinhelper/auxcode.cpp
@@ -68,11 +68,8 @@ bool AuxCode::matchPhrase(const std::string &phrase,
 
     // Single character: check if any code starts with input
     if (charCount == 1) {
-        std::string chr;
-        for (auto iter = std::begin(charRange); iter != std::end(charRange);
-             ++iter) {
-            chr.assign(iter.charRange().first, iter.charRange().second);
-        }
+        auto iter = std::begin(charRange);
+        std::string chr(iter.charRange().first, iter.charRange().second);
         auto it = table_.find(chr);
         if (it == table_.end()) {
             return false;
@@ -91,7 +88,7 @@ bool AuxCode::matchPhrase(const std::string &phrase,
     }
 
     std::string firstCodes;
-    firstCodes.reserve(charCount);
+    firstCodes.reserve(static_cast<size_t>(charCount));
     for (auto iter = std::begin(charRange); iter != std::end(charRange);
          ++iter) {
         std::string chr(iter.charRange().first, iter.charRange().second);

--- a/modules/pinyinhelper/auxcode.cpp
+++ b/modules/pinyinhelper/auxcode.cpp
@@ -44,6 +44,13 @@ void AuxCode::loadFromFile(const std::string &path) {
     loaded_ = true;
 }
 
+void AuxCode::loadFromStream(std::istream &in) {
+    table_.clear();
+    loaded_ = false;
+    parseStream(in);
+    loaded_ = true;
+}
+
 void AuxCode::parseStream(std::istream &in) {
     std::string buf;
     while (std::getline(in, buf)) {

--- a/modules/pinyinhelper/auxcode.cpp
+++ b/modules/pinyinhelper/auxcode.cpp
@@ -18,13 +18,13 @@ void AuxCode::loadProfile(const std::string &profile) {
     if (profile == loadedProfile_ && loaded_) {
         return;
     }
+    table_.clear();
+    loaded_ = false;
     auto path = stringutils::concat("pinyin/auxcode/", profile);
     auto file = StandardPaths::global().open(StandardPathsType::PkgData, path);
     if (!file.isValid()) {
         return;
     }
-    table_.clear();
-    loaded_ = false;
     IFDStreamBuf buffer(file.fd());
     std::istream in(&buffer);
     parseStream(in);

--- a/modules/pinyinhelper/auxcode.cpp
+++ b/modules/pinyinhelper/auxcode.cpp
@@ -6,6 +6,7 @@
  */
 #include "auxcode.h"
 
+#include <fcitx-utils/stringutils.h>
 #include <fcitx-utils/utf8.h>
 #include <fstream>
 
@@ -20,8 +21,12 @@ void AuxCode::loadFromFile(const std::string &path) {
         return;
     }
 
-    std::string line;
-    while (std::getline(file, line)) {
+    std::string buf;
+    while (std::getline(file, buf)) {
+        if (!utf8::validate(buf)) {
+            continue;
+        }
+        auto line = stringutils::trimView(buf);
         if (line.empty() || line[0] == '#') {
             continue;
         }
@@ -29,15 +34,15 @@ void AuxCode::loadFromFile(const std::string &path) {
         if (pos == std::string::npos || pos == 0) {
             continue;
         }
-        std::string character = line.substr(0, pos);
-        std::string code = line.substr(pos + 1);
+        auto character = line.substr(0, pos);
+        auto code = line.substr(pos + 1);
         if (character.empty() || code.empty()) {
             continue;
         }
-        if (utf8::length(character) != 1) {
+        if (utf8::lengthValidated(character) != 1) {
             continue;
         }
-        table_[character].push_back(code);
+        table_[std::string(character)].push_back(std::string(code));
     }
 
     loaded_ = true;
@@ -96,7 +101,8 @@ bool AuxCode::matchPhrase(const std::string &phrase,
         if (code.empty()) {
             return false;
         }
-        firstCodes += code[0];
+        // Aux codes are ASCII single-byte characters, take the first byte
+        firstCodes += code.front();
     }
 
     for (size_t i = 0; i < inputLen; ++i) {

--- a/modules/pinyinhelper/auxcode.cpp
+++ b/modules/pinyinhelper/auxcode.cpp
@@ -43,20 +43,6 @@ void AuxCode::loadFromFile(const std::string &path) {
     loaded_ = true;
 }
 
-bool AuxCode::anyCodeStartsWith(const std::string &character,
-                                const std::string &prefix) const {
-    auto it = table_.find(character);
-    if (it == table_.end()) {
-        return false;
-    }
-    for (const auto &code : it->second) {
-        if (code.starts_with(prefix)) {
-            return true;
-        }
-    }
-    return false;
-}
-
 std::string AuxCode::getFirstCode(const std::string &character) const {
     auto it = table_.find(character);
     if (it == table_.end() || it->second.empty()) {

--- a/modules/pinyinhelper/auxcode.cpp
+++ b/modules/pinyinhelper/auxcode.cpp
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: 2024
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ */
+#include "auxcode.h"
+
+#include <fcitx-utils/utf8.h>
+#include <fstream>
+#include <string_view>
+
+namespace fcitx {
+
+void AuxCode::loadFromFile(const std::string &path) {
+    table_.clear();
+    loaded_ = false;
+
+    std::ifstream file(path);
+    if (!file.is_open()) {
+        return;
+    }
+
+    std::string line;
+    while (std::getline(file, line)) {
+        if (line.empty() || line[0] == '#') {
+            continue;
+        }
+        auto pos = line.find('=');
+        if (pos == std::string::npos || pos == 0) {
+            continue;
+        }
+        std::string character = line.substr(0, pos);
+        std::string code = line.substr(pos + 1);
+        if (character.empty() || code.empty()) {
+            continue;
+        }
+        if (utf8::length(character) != 1) {
+            continue;
+        }
+        table_[character].push_back(code);
+    }
+
+    loaded_ = true;
+}
+
+bool AuxCode::anyCodeStartsWith(const std::string &character,
+                                const std::string &prefix) const {
+    auto it = table_.find(character);
+    if (it == table_.end()) {
+        return false;
+    }
+    for (const auto &code : it->second) {
+        if (code.starts_with(prefix)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::string AuxCode::getFirstCode(const std::string &character) const {
+    auto it = table_.find(character);
+    if (it == table_.end() || it->second.empty()) {
+        return {};
+    }
+    return it->second.front();
+}
+
+bool AuxCode::matchPhrase(const std::string &phrase,
+                          const std::string &auxInput) const {
+    if (!loaded_ || auxInput.empty()) {
+        return true;
+    }
+
+    auto charRange = utf8::MakeUTF8CharRange(phrase);
+    auto charCount = utf8::lengthValidated(phrase);
+
+    if (charCount == utf8::INVALID_LENGTH || charCount == 0) {
+        return true;
+    }
+
+    size_t inputLen = auxInput.size();
+
+    if (inputLen > static_cast<size_t>(charCount)) {
+        return false;
+    }
+
+    std::string firstCodes;
+    firstCodes.reserve(charCount);
+    for (auto iter = std::begin(charRange); iter != std::end(charRange);
+         ++iter) {
+        std::string chr(iter.charRange().first, iter.charRange().second);
+        auto code = getFirstCode(chr);
+        if (code.empty()) {
+            return false;
+        }
+        firstCodes += code[0];
+    }
+
+    for (size_t i = 0; i < inputLen; ++i) {
+        if (firstCodes[i] != auxInput[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+} // namespace fcitx

--- a/modules/pinyinhelper/auxcode.h
+++ b/modules/pinyinhelper/auxcode.h
@@ -21,12 +21,11 @@ public:
     void loadFromFile(const std::string &path);
     bool isLoaded() const { return loaded_; }
 
-    // Public for unit tests; internal use by matchPhrase only.
-    std::string getFirstCode(const std::string &character) const;
     bool matchPhrase(const std::string &phrase,
                      const std::string &auxInput) const;
 
 private:
+    std::string getFirstCode(const std::string &character) const;
     void parseStream(std::istream &in);
 
     std::unordered_map<std::string, std::vector<std::string>> table_;

--- a/modules/pinyinhelper/auxcode.h
+++ b/modules/pinyinhelper/auxcode.h
@@ -19,6 +19,7 @@ public:
 
     void loadProfile(const std::string &profile);
     void loadFromFile(const std::string &path);
+    void loadFromStream(std::istream &in);
     bool isLoaded() const { return loaded_; }
 
     bool matchPhrase(const std::string &phrase,

--- a/modules/pinyinhelper/auxcode.h
+++ b/modules/pinyinhelper/auxcode.h
@@ -20,6 +20,7 @@ public:
     void loadFromFile(const std::string &path);
     bool isLoaded() const { return loaded_; }
 
+    // Public for unit tests; internal use by matchPhrase only.
     std::string getFirstCode(const std::string &character) const;
     bool matchPhrase(const std::string &phrase,
                      const std::string &auxInput) const;

--- a/modules/pinyinhelper/auxcode.h
+++ b/modules/pinyinhelper/auxcode.h
@@ -20,8 +20,6 @@ public:
     void loadFromFile(const std::string &path);
     bool isLoaded() const { return loaded_; }
 
-    bool anyCodeStartsWith(const std::string &character,
-                           const std::string &prefix) const;
     std::string getFirstCode(const std::string &character) const;
     bool matchPhrase(const std::string &phrase,
                      const std::string &auxInput) const;

--- a/modules/pinyinhelper/auxcode.h
+++ b/modules/pinyinhelper/auxcode.h
@@ -18,6 +18,7 @@ public:
     AuxCode() = default;
 
     void loadFromFile(const std::string &path);
+    void loadFromFD(int fd);
     bool isLoaded() const { return loaded_; }
 
     // Public for unit tests; internal use by matchPhrase only.
@@ -26,6 +27,8 @@ public:
                      const std::string &auxInput) const;
 
 private:
+    void parseStream(std::istream &in);
+
     std::unordered_map<std::string, std::vector<std::string>> table_;
     bool loaded_ = false;
 };

--- a/modules/pinyinhelper/auxcode.h
+++ b/modules/pinyinhelper/auxcode.h
@@ -17,8 +17,8 @@ class AuxCode {
 public:
     AuxCode() = default;
 
+    void loadProfile(const std::string &profile);
     void loadFromFile(const std::string &path);
-    void loadFromFD(int fd);
     bool isLoaded() const { return loaded_; }
 
     // Public for unit tests; internal use by matchPhrase only.
@@ -30,6 +30,7 @@ private:
     void parseStream(std::istream &in);
 
     std::unordered_map<std::string, std::vector<std::string>> table_;
+    std::string loadedProfile_;
     bool loaded_ = false;
 };
 

--- a/modules/pinyinhelper/auxcode.h
+++ b/modules/pinyinhelper/auxcode.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024
+ * SPDX-FileCopyrightText: 2026
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *

--- a/modules/pinyinhelper/auxcode.h
+++ b/modules/pinyinhelper/auxcode.h
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: 2024
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ */
+#ifndef _PINYINHELPER_AUXCODE_H_
+#define _PINYINHELPER_AUXCODE_H_
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace fcitx {
+
+class AuxCode {
+public:
+    AuxCode() = default;
+
+    void loadFromFile(const std::string &path);
+    bool isLoaded() const { return loaded_; }
+
+    bool anyCodeStartsWith(const std::string &character,
+                           const std::string &prefix) const;
+    std::string getFirstCode(const std::string &character) const;
+    bool matchPhrase(const std::string &phrase,
+                     const std::string &auxInput) const;
+
+private:
+    std::unordered_map<std::string, std::vector<std::string>> table_;
+    bool loaded_ = false;
+};
+
+} // namespace fcitx
+
+#endif // _PINYINHELPER_AUXCODE_H_

--- a/modules/pinyinhelper/pinyinhelper.cpp
+++ b/modules/pinyinhelper/pinyinhelper.cpp
@@ -10,8 +10,10 @@
 #include <clipboard_public.h>
 #include <fcitx-config/iniparser.h>
 #include <fcitx-utils/event.h>
+#include <fcitx-utils/fdstreambuf.h>
 #include <fcitx-utils/i18n.h>
 #include <fcitx-utils/standardpaths.h>
+#include <fcitx-utils/stringutils.h>
 #include <fcitx-utils/utf8.h>
 #include <fcitx/addonfactory.h>
 #include <fcitx/inputcontext.h>
@@ -153,15 +155,22 @@ std::string PinyinHelper::prettyStrokeString(const std::string &input) {
     return stroke_.prettyString(input);
 }
 
-void PinyinHelper::loadAuxCode(const std::string &path) {
-    auxCode_.loadFromFile(path);
+void PinyinHelper::loadAuxCode(const std::string &profile) {
+    if (profile == loadedProfile_ && auxCode_.isLoaded()) {
+        return;
+    }
+    auto auxPath = stringutils::concat("pinyin/auxcode/", profile);
+    auto file = StandardPaths::global().open(StandardPathsType::PkgData,
+                                             auxPath);
+    if (!file.isValid()) {
+        return;
+    }
+    auxCode_.loadFromFD(file.fd());
+    loadedProfile_ = profile;
 }
 
 bool PinyinHelper::matchAuxCode(const std::string &text,
                                 const std::string &auxInput) const {
-    if (!auxCode_.isLoaded()) {
-        return true;
-    }
     return auxCode_.matchPhrase(text, auxInput);
 }
 

--- a/modules/pinyinhelper/pinyinhelper.cpp
+++ b/modules/pinyinhelper/pinyinhelper.cpp
@@ -153,6 +153,38 @@ std::string PinyinHelper::prettyStrokeString(const std::string &input) {
     return stroke_.prettyString(input);
 }
 
+void PinyinHelper::loadAuxCode(const std::string &path) {
+    auxCode_.loadFromFile(path);
+}
+
+bool PinyinHelper::matchAuxCode(const std::string &text,
+                                const std::string &auxInput) const {
+    if (!auxCode_.isLoaded()) {
+        return true;
+    }
+    auto charRange = utf8::MakeUTF8CharRange(text);
+    auto charCount = utf8::lengthValidated(text);
+
+    if (charCount == utf8::INVALID_LENGTH || charCount == 0) {
+        return true;
+    }
+
+    if (auxInput.empty()) {
+        return true;
+    }
+
+    if (charCount == 1) {
+        std::string chr;
+        for (auto iter = std::begin(charRange); iter != std::end(charRange);
+             ++iter) {
+            chr.assign(iter.charRange().first, iter.charRange().second);
+        }
+        return auxCode_.anyCodeStartsWith(chr, auxInput);
+    }
+
+    return auxCode_.matchPhrase(text, auxInput);
+}
+
 class PinyinHelperModuleFactory : public AddonFactory {
     AddonInstance *create(AddonManager *manager) override {
         registerDomain("fcitx5-chinese-addons", FCITX_INSTALL_LOCALEDIR);

--- a/modules/pinyinhelper/pinyinhelper.cpp
+++ b/modules/pinyinhelper/pinyinhelper.cpp
@@ -10,9 +10,7 @@
 #include <clipboard_public.h>
 #include <fcitx-config/iniparser.h>
 #include <fcitx-utils/event.h>
-#include <fcitx-utils/fdstreambuf.h>
 #include <fcitx-utils/i18n.h>
-#include <fcitx-utils/standardpaths.h>
 #include <fcitx-utils/stringutils.h>
 #include <fcitx-utils/utf8.h>
 #include <fcitx/addonfactory.h>
@@ -156,17 +154,7 @@ std::string PinyinHelper::prettyStrokeString(const std::string &input) {
 }
 
 void PinyinHelper::loadAuxCode(const std::string &profile) {
-    if (profile == loadedProfile_ && auxCode_.isLoaded()) {
-        return;
-    }
-    auto auxPath = stringutils::concat("pinyin/auxcode/", profile);
-    auto file = StandardPaths::global().open(StandardPathsType::PkgData,
-                                             auxPath);
-    if (!file.isValid()) {
-        return;
-    }
-    auxCode_.loadFromFD(file.fd());
-    loadedProfile_ = profile;
+    auxCode_.loadProfile(profile);
 }
 
 bool PinyinHelper::matchAuxCode(const std::string &text,

--- a/modules/pinyinhelper/pinyinhelper.cpp
+++ b/modules/pinyinhelper/pinyinhelper.cpp
@@ -162,26 +162,6 @@ bool PinyinHelper::matchAuxCode(const std::string &text,
     if (!auxCode_.isLoaded()) {
         return true;
     }
-    auto charRange = utf8::MakeUTF8CharRange(text);
-    auto charCount = utf8::lengthValidated(text);
-
-    if (charCount == utf8::INVALID_LENGTH || charCount == 0) {
-        return true;
-    }
-
-    if (auxInput.empty()) {
-        return true;
-    }
-
-    if (charCount == 1) {
-        std::string chr;
-        for (auto iter = std::begin(charRange); iter != std::end(charRange);
-             ++iter) {
-            chr.assign(iter.charRange().first, iter.charRange().second);
-        }
-        return auxCode_.anyCodeStartsWith(chr, auxInput);
-    }
-
     return auxCode_.matchPhrase(text, auxInput);
 }
 

--- a/modules/pinyinhelper/pinyinhelper.h
+++ b/modules/pinyinhelper/pinyinhelper.h
@@ -53,7 +53,6 @@ private:
     PinyinLookup lookup_;
     Stroke stroke_;
     AuxCode auxCode_;
-    std::string loadedProfile_;
     std::unique_ptr<EventSource> deferEvent_;
     std::unique_ptr<HandlerTableEntry<QuickPhraseProviderCallback>> handler_;
 };

--- a/modules/pinyinhelper/pinyinhelper.h
+++ b/modules/pinyinhelper/pinyinhelper.h
@@ -7,6 +7,7 @@
 #ifndef _PINYINHELPER_PINYINHELPER_H_
 #define _PINYINHELPER_PINYINHELPER_H_
 
+#include "auxcode.h"
 #include "pinyinhelper_public.h"
 #include "pinyinlookup.h"
 #include "stroke.h"
@@ -31,6 +32,8 @@ public:
     std::string reverseLookupStroke(const std::string &input);
     std::string prettyStrokeString(const std::string &input);
     void loadStroke();
+    void loadAuxCode(const std::string &path);
+    bool matchAuxCode(const std::string &text, const std::string &auxInput) const;
 
     FCITX_ADDON_EXPORT_FUNCTION(PinyinHelper, lookup);
     FCITX_ADDON_EXPORT_FUNCTION(PinyinHelper, fullLookup);
@@ -38,6 +41,8 @@ public:
     FCITX_ADDON_EXPORT_FUNCTION(PinyinHelper, loadStroke);
     FCITX_ADDON_EXPORT_FUNCTION(PinyinHelper, reverseLookupStroke);
     FCITX_ADDON_EXPORT_FUNCTION(PinyinHelper, prettyStrokeString);
+    FCITX_ADDON_EXPORT_FUNCTION(PinyinHelper, loadAuxCode);
+    FCITX_ADDON_EXPORT_FUNCTION(PinyinHelper, matchAuxCode);
 
     FCITX_ADDON_DEPENDENCY_LOADER(quickphrase, instance_->addonManager());
     FCITX_ADDON_DEPENDENCY_LOADER(clipboard, instance_->addonManager());
@@ -47,6 +52,7 @@ private:
     Instance *instance_;
     PinyinLookup lookup_;
     Stroke stroke_;
+    AuxCode auxCode_;
     std::unique_ptr<EventSource> deferEvent_;
     std::unique_ptr<HandlerTableEntry<QuickPhraseProviderCallback>> handler_;
 };

--- a/modules/pinyinhelper/pinyinhelper.h
+++ b/modules/pinyinhelper/pinyinhelper.h
@@ -53,6 +53,7 @@ private:
     PinyinLookup lookup_;
     Stroke stroke_;
     AuxCode auxCode_;
+    std::string loadedProfile_;
     std::unique_ptr<EventSource> deferEvent_;
     std::unique_ptr<HandlerTableEntry<QuickPhraseProviderCallback>> handler_;
 };

--- a/modules/pinyinhelper/pinyinhelper.h
+++ b/modules/pinyinhelper/pinyinhelper.h
@@ -32,7 +32,7 @@ public:
     std::string reverseLookupStroke(const std::string &input);
     std::string prettyStrokeString(const std::string &input);
     void loadStroke();
-    void loadAuxCode(const std::string &path);
+    void loadAuxCode(const std::string &profile);
     bool matchAuxCode(const std::string &text, const std::string &auxInput) const;
 
     FCITX_ADDON_EXPORT_FUNCTION(PinyinHelper, lookup);

--- a/modules/pinyinhelper/pinyinhelper_public.h
+++ b/modules/pinyinhelper/pinyinhelper_public.h
@@ -25,5 +25,9 @@ FCITX_ADDON_DECLARE_FUNCTION(PinyinHelper, reverseLookupStroke,
 FCITX_ADDON_DECLARE_FUNCTION(PinyinHelper, prettyStrokeString,
                              std::string(const std::string &));
 FCITX_ADDON_DECLARE_FUNCTION(PinyinHelper, loadStroke, void());
+FCITX_ADDON_DECLARE_FUNCTION(PinyinHelper, loadAuxCode,
+                             void(const std::string &));
+FCITX_ADDON_DECLARE_FUNCTION(PinyinHelper, matchAuxCode,
+                             bool(const std::string &, const std::string &));
 
 #endif // _PINYINHELPER_PINYINHELPER_PUBLIC_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,11 @@ target_link_libraries(testpinyinhelper Fcitx5::Core Fcitx5::Module::PinyinHelper
 add_dependencies(testpinyinhelper pinyin pinyin.conf.in-fmt pinyinhelper pinyinhelper.conf.in-fmt)
 add_test(NAME testpinyinhelper COMMAND testpinyinhelper)
 
+add_executable(testauxcode testauxcode.cpp ../modules/pinyinhelper/auxcode.cpp)
+target_include_directories(testauxcode PRIVATE ${CMAKE_SOURCE_DIR}/modules/pinyinhelper)
+target_link_libraries(testauxcode Fcitx5::Utils)
+add_test(NAME testauxcode COMMAND testauxcode)
+
 add_executable(testfullwidth testfullwidth.cpp)
 target_link_libraries(testfullwidth Fcitx5::Core Fcitx5::Module::TestFrontend Fcitx5::Module::TestIM)
 add_dependencies(testfullwidth fullwidth fullwidth.conf.in-fmt)

--- a/test/testauxcode.cpp
+++ b/test/testauxcode.cpp
@@ -24,7 +24,6 @@ static void testEmptyTable() {
     assert(!aux.isLoaded());
     aux.loadFromFile("/nonexistent/path.txt");
     assert(!aux.isLoaded());
-    assert(!aux.anyCodeStartsWith("时", "o"));
     assert(aux.getFirstCode("时").empty());
     assert(aux.matchPhrase("时间", "om"));
 }
@@ -48,14 +47,13 @@ static void testLoadAndSingleCharMatch() {
     aux.loadFromFile(path);
     assert(aux.isLoaded());
 
-    assert(aux.anyCodeStartsWith("时", "o"));
-    assert(aux.anyCodeStartsWith("时", "oc"));
-    assert(!aux.anyCodeStartsWith("时", "m"));
-    assert(!aux.anyCodeStartsWith("时", "ocd"));
+    // single char: inputLen must be <= 1
+    assert(aux.matchPhrase("时", "o"));
+    assert(!aux.matchPhrase("时", "oc"));
+    assert(!aux.matchPhrase("时", "m"));
 
-    assert(aux.anyCodeStartsWith("魔", "g"));
-    assert(aux.anyCodeStartsWith("魔", "gg"));
-    assert(!aux.anyCodeStartsWith("魔", "ggo"));
+    assert(aux.matchPhrase("魔", "g"));
+    assert(!aux.matchPhrase("魔", "gg"));
 
     std::remove(path.c_str());
 }
@@ -85,10 +83,11 @@ static void testMultiCode() {
     AuxCode aux;
     aux.loadFromFile(path);
 
-    assert(aux.anyCodeStartsWith("厑", "i"));
-    assert(aux.anyCodeStartsWith("厑", "ib"));
-    assert(aux.anyCodeStartsWith("厑", "ii"));
-    assert(!aux.anyCodeStartsWith("厑", "x"));
+    // single char: only one letter matches
+    assert(aux.matchPhrase("厑", "i"));
+    assert(!aux.matchPhrase("厑", "ib"));
+    assert(!aux.matchPhrase("厑", "ii"));
+    assert(!aux.matchPhrase("厑", "x"));
 
     std::remove(path.c_str());
 }
@@ -149,11 +148,13 @@ static void testStrokeKeyChars() {
 
     AuxCode aux;
     aux.loadFromFile(path);
-    assert(aux.anyCodeStartsWith("一", "h"));
-    assert(aux.anyCodeStartsWith("丨", "s"));
-    assert(aux.anyCodeStartsWith("丿", "p"));
-    assert(aux.anyCodeStartsWith("㇏", "n"));
-    assert(aux.anyCodeStartsWith("𠃍", "z"));
+    assert(aux.matchPhrase("一", "h"));
+    assert(aux.matchPhrase("丨", "s"));
+    assert(aux.matchPhrase("丿", "p"));
+    assert(aux.matchPhrase("㇏", "n"));
+    assert(aux.matchPhrase("𠃍", "z"));
+    // single char: longer input rejected
+    assert(!aux.matchPhrase("一", "hx"));
 
     std::remove(path.c_str());
 }

--- a/test/testauxcode.cpp
+++ b/test/testauxcode.cpp
@@ -23,6 +23,7 @@ static void writeTestTable(const std::string &path, const std::string &content) 
     f.close();
 }
 
+// File not found: isLoaded=false, matchPhrase passes through
 static void testEmptyTable() {
     AuxCode aux;
     FCITX_ASSERT(!aux.isLoaded());
@@ -32,6 +33,7 @@ static void testEmptyTable() {
     FCITX_ASSERT(aux.matchPhrase("时间", "om"));
 }
 
+// Single character: prefix match and boundary
 static void testSingleCharMatch() {
     auto path = tempPath("single");
     writeTestTable(path, R"(时=oc
@@ -56,6 +58,7 @@ static void testSingleCharMatch() {
     std::remove(path.c_str());
 }
 
+// One character with multiple codes: any code matches
 static void testMultipleCodes() {
     auto path = tempPath("multi");
     writeTestTable(path, R"(厑=ib
@@ -75,6 +78,7 @@ static void testMultipleCodes() {
     std::remove(path.c_str());
 }
 
+// getFirstCode returns first code for character
 static void testGetFirstCode() {
     auto path = tempPath("first");
     writeTestTable(path, R"(时=oc
@@ -90,6 +94,7 @@ static void testGetFirstCode() {
     std::remove(path.c_str());
 }
 
+// Phrase matching: prefix, exact, mismatch, unmatched char, empty input, mixed content
 static void testMatchPhrase() {
     auto path = tempPath("phrase");
     writeTestTable(path, R"(时=oc
@@ -140,6 +145,7 @@ A=a
     std::remove(path.c_str());
 }
 
+// File opened but no valid entries
 static void testEmptyContent() {
     auto path = tempPath("empty");
     writeTestTable(path, "# comment\n\n");

--- a/test/testauxcode.cpp
+++ b/test/testauxcode.cpp
@@ -1,0 +1,223 @@
+/*
+ * SPDX-FileCopyrightText: 2024
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ */
+#include "auxcode.h"
+#include <cassert>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+using namespace fcitx;
+
+static void writeTestTable(const std::string &path, const std::string &content) {
+    std::ofstream f(path);
+    f << content;
+    f.close();
+}
+
+static void testEmptyTable() {
+    AuxCode aux;
+    assert(!aux.isLoaded());
+    aux.loadFromFile("/nonexistent/path.txt");
+    assert(!aux.isLoaded());
+    assert(!aux.anyCodeStartsWith("时", "o"));
+    assert(aux.getFirstCode("时").empty());
+    assert(aux.matchPhrase("时间", "om"));
+}
+
+static void testLoadAndSingleCharMatch() {
+    const std::string path = "/tmp/test_aux_code.txt";
+    writeTestTable(path, R"(# comment line
+时=oc
+间=mo
+实=bd
+践=jc
+魔=gg
+法=ds
+少=xp
+女=va
+人=pn
+体=rb
+)");
+
+    AuxCode aux;
+    aux.loadFromFile(path);
+    assert(aux.isLoaded());
+
+    assert(aux.anyCodeStartsWith("时", "o"));
+    assert(aux.anyCodeStartsWith("时", "oc"));
+    assert(!aux.anyCodeStartsWith("时", "m"));
+    assert(!aux.anyCodeStartsWith("时", "ocd"));
+
+    assert(aux.anyCodeStartsWith("魔", "g"));
+    assert(aux.anyCodeStartsWith("魔", "gg"));
+    assert(!aux.anyCodeStartsWith("魔", "ggo"));
+
+    std::remove(path.c_str());
+}
+
+static void testGetFirstCode() {
+    const std::string path = "/tmp/test_aux_code_first.txt";
+    writeTestTable(path, R"(时=oc
+间=mo
+)");
+
+    AuxCode aux;
+    aux.loadFromFile(path);
+    assert(aux.getFirstCode("时") == "oc");
+    assert(aux.getFirstCode("间") == "mo");
+    assert(aux.getFirstCode("不").empty());
+
+    std::remove(path.c_str());
+}
+
+static void testMultiCode() {
+    const std::string path = "/tmp/test_aux_code_multi.txt";
+    writeTestTable(path, R"(厑=ib
+厑=ii
+魔=gg
+)");
+
+    AuxCode aux;
+    aux.loadFromFile(path);
+
+    assert(aux.anyCodeStartsWith("厑", "i"));
+    assert(aux.anyCodeStartsWith("厑", "ib"));
+    assert(aux.anyCodeStartsWith("厑", "ii"));
+    assert(!aux.anyCodeStartsWith("厑", "x"));
+
+    std::remove(path.c_str());
+}
+
+static void testMatchPhrase() {
+    const std::string path = "/tmp/test_aux_code_phrase.txt";
+    writeTestTable(path, R"(时=oc
+间=mo
+实=bd
+践=jc
+魔=gg
+法=ds
+少=xp
+女=va
+人=pn
+体=rb
+)");
+
+    AuxCode aux;
+    aux.loadFromFile(path);
+
+    // input length < char count -> prefix match -> keep
+    assert(aux.matchPhrase("时间", "o"));
+    assert(aux.matchPhrase("时间", "om"));
+    assert(aux.matchPhrase("魔法少女", "g"));
+    assert(aux.matchPhrase("魔法少女", "gd"));
+    assert(aux.matchPhrase("魔法少女", "gdx"));
+
+    // input length == char count, all match -> keep
+    assert(aux.matchPhrase("时间", "om"));
+    assert(aux.matchPhrase("魔法少女", "gdxv"));
+
+    // input length == char count, mismatch -> filter
+    assert(!aux.matchPhrase("时间", "og"));
+    assert(!aux.matchPhrase("时间", "xm"));
+
+    // input length > char count -> filter
+    assert(!aux.matchPhrase("时间", "omx"));
+    assert(!aux.matchPhrase("魔法少女", "gdxvy"));
+
+    // unmatched character -> filter entire phrase
+    assert(!aux.matchPhrase("没时间", "o"));
+
+    // empty input -> keep
+    assert(aux.matchPhrase("时间", ""));
+
+    std::remove(path.c_str());
+}
+
+static void testStrokeKeyChars() {
+    const std::string path = "/tmp/test_aux_code_stroke.txt";
+    writeTestTable(path, R"(一=h
+丨=s
+丿=p
+㇏=n
+𠃍=z
+)");
+
+    AuxCode aux;
+    aux.loadFromFile(path);
+    assert(aux.anyCodeStartsWith("一", "h"));
+    assert(aux.anyCodeStartsWith("丨", "s"));
+    assert(aux.anyCodeStartsWith("丿", "p"));
+    assert(aux.anyCodeStartsWith("㇏", "n"));
+    assert(aux.anyCodeStartsWith("𠃍", "z"));
+
+    std::remove(path.c_str());
+}
+
+static void testBehaviorExamples() {
+    const std::string path = "/tmp/test_aux_code_examples.txt";
+    writeTestTable(path, R"(时=oc
+间=mo
+实=bd
+践=jc
+魔=gg
+法=ds
+少=xp
+女=va
+人=pn
+体=rb
+多=dk
+啦=kl
+A=a
+梦=mx
+)");
+
+    AuxCode aux;
+    aux.loadFromFile(path);
+
+    // Example 1: shijian + "o"
+    assert(aux.matchPhrase("时间", "o"));
+    assert(!aux.matchPhrase("实践", "o"));
+
+    // Example 1: shijian + "om"
+    assert(aux.matchPhrase("时间", "om"));
+
+    // Example 2: mofaxxx + "g"
+    assert(aux.matchPhrase("魔法少女", "g"));
+    assert(aux.matchPhrase("魔法少女", "gd"));
+    assert(aux.matchPhrase("魔法少女", "gdx"));
+    assert(aux.matchPhrase("魔法少女", "gdxv"));
+    assert(!aux.matchPhrase("魔法少女", "gdxvy"));
+
+    // Example 3: renjianti
+    assert(aux.matchPhrase("人间体", "p"));
+    assert(aux.matchPhrase("人间体", "pm"));
+    assert(aux.matchPhrase("人间体", "pmr"));
+    assert(!aux.matchPhrase("人间体", "pmrx"));
+
+    // Multi-char codes
+    assert(aux.matchPhrase("多啦A梦", "d"));
+    assert(aux.matchPhrase("多啦A梦", "dk"));
+    assert(aux.matchPhrase("多啦A梦", "dka"));
+    assert(aux.matchPhrase("多啦A梦", "dkam"));
+    assert(!aux.matchPhrase("多啦A梦", "dkamx"));
+
+    std::remove(path.c_str());
+}
+
+int main() {
+    testEmptyTable();
+    testLoadAndSingleCharMatch();
+    testGetFirstCode();
+    testMultiCode();
+    testMatchPhrase();
+    testStrokeKeyChars();
+    testBehaviorExamples();
+
+    std::cout << "All auxcode tests passed!" << std::endl;
+    return 0;
+}

--- a/test/testauxcode.cpp
+++ b/test/testauxcode.cpp
@@ -87,74 +87,6 @@ static void testMatchPhrase() {
 女=va
 人=pn
 体=rb
-)");
-
-    AuxCode aux;
-    aux.loadFromFile(path);
-
-    // input length < char count -> prefix match -> keep
-    assert(aux.matchPhrase("时间", "o"));
-    assert(aux.matchPhrase("时间", "om"));
-    assert(aux.matchPhrase("魔法少女", "g"));
-    assert(aux.matchPhrase("魔法少女", "gd"));
-    assert(aux.matchPhrase("魔法少女", "gdx"));
-
-    // input length == char count, all match -> keep
-    assert(aux.matchPhrase("时间", "om"));
-    assert(aux.matchPhrase("魔法少女", "gdxv"));
-
-    // input length == char count, mismatch -> filter
-    assert(!aux.matchPhrase("时间", "og"));
-    assert(!aux.matchPhrase("时间", "xm"));
-
-    // input length > char count -> filter
-    assert(!aux.matchPhrase("时间", "omx"));
-    assert(!aux.matchPhrase("魔法少女", "gdxvy"));
-
-    // unmatched character -> filter entire phrase
-    assert(!aux.matchPhrase("没时间", "o"));
-
-    // empty input -> keep
-    assert(aux.matchPhrase("时间", ""));
-
-    std::remove(path.c_str());
-}
-
-static void testStrokeKeyChars() {
-    const std::string path = "/tmp/test_aux_code_stroke.txt";
-    writeTestTable(path, R"(一=h
-丨=s
-丿=p
-㇏=n
-𠃍=z
-)");
-
-    AuxCode aux;
-    aux.loadFromFile(path);
-    assert(aux.matchPhrase("一", "h"));
-    assert(aux.matchPhrase("丨", "s"));
-    assert(aux.matchPhrase("丿", "p"));
-    assert(aux.matchPhrase("㇏", "n"));
-    assert(aux.matchPhrase("𠃍", "z"));
-    // single char: prefix match
-    assert(aux.matchPhrase("一", "h"));
-    assert(!aux.matchPhrase("一", "hx"));
-
-    std::remove(path.c_str());
-}
-
-static void testBehaviorExamples() {
-    const std::string path = "/tmp/test_aux_code_examples.txt";
-    writeTestTable(path, R"(时=oc
-间=mo
-实=bd
-践=jc
-魔=gg
-法=ds
-少=xp
-女=va
-人=pn
-体=rb
 多=dk
 啦=kl
 A=a
@@ -164,27 +96,26 @@ A=a
     AuxCode aux;
     aux.loadFromFile(path);
 
-    // Example 1: shijian + "o"
-    assert(aux.matchPhrase("时间", "o"));
-    assert(!aux.matchPhrase("实践", "o"));
-
-    // Example 1: shijian + "om"
-    assert(aux.matchPhrase("时间", "om"));
-
-    // Example 2: mofaxxx + "g"
+    // prefix match
     assert(aux.matchPhrase("魔法少女", "g"));
     assert(aux.matchPhrase("魔法少女", "gd"));
     assert(aux.matchPhrase("魔法少女", "gdx"));
-    assert(aux.matchPhrase("魔法少女", "gdxv"));
-    assert(!aux.matchPhrase("魔法少女", "gdxvy"));
 
-    // Example 3: renjianti
-    assert(aux.matchPhrase("人间体", "p"));
-    assert(aux.matchPhrase("人间体", "pm"));
+    // exact match
+    assert(aux.matchPhrase("魔法少女", "gdxv"));
     assert(aux.matchPhrase("人间体", "pmr"));
+
+    // mismatch
+    assert(!aux.matchPhrase("魔法少女", "gdxvy"));
     assert(!aux.matchPhrase("人间体", "pmrx"));
 
-    // Multi-char codes
+    // unmatched character -> filter entire phrase
+    assert(!aux.matchPhrase("没时间", "o"));
+
+    // empty input -> keep
+    assert(aux.matchPhrase("魔法少女", ""));
+
+    // multi-char codes with English
     assert(aux.matchPhrase("多啦A梦", "d"));
     assert(aux.matchPhrase("多啦A梦", "dk"));
     assert(aux.matchPhrase("多啦A梦", "dka"));
@@ -199,8 +130,6 @@ int main() {
     testSingleCharMatch();
     testGetFirstCode();
     testMatchPhrase();
-    testStrokeKeyChars();
-    testBehaviorExamples();
 
     std::cout << "All auxcode tests passed!" << std::endl;
     return 0;

--- a/test/testauxcode.cpp
+++ b/test/testauxcode.cpp
@@ -29,7 +29,6 @@ static void testEmptyTable() {
     FCITX_ASSERT(!aux.isLoaded());
     aux.loadFromFile("/nonexistent/path.txt");
     FCITX_ASSERT(!aux.isLoaded());
-    FCITX_ASSERT(aux.getFirstCode("时").empty());
     FCITX_ASSERT(aux.matchPhrase("时间", "om"));
 }
 
@@ -74,22 +73,6 @@ static void testMultipleCodes() {
     FCITX_ASSERT(aux.matchPhrase("厑", "ib"));
     FCITX_ASSERT(aux.matchPhrase("厑", "ii"));
     FCITX_ASSERT(!aux.matchPhrase("厑", "x"));
-
-    std::remove(path.c_str());
-}
-
-// getFirstCode returns first code for character
-static void testGetFirstCode() {
-    auto path = tempPath("first");
-    writeTestTable(path, R"(时=oc
-间=mo
-)");
-
-    AuxCode aux;
-    aux.loadFromFile(path);
-    FCITX_ASSERT(aux.getFirstCode("时") == "oc") << aux.getFirstCode("时");
-    FCITX_ASSERT(aux.getFirstCode("间") == "mo") << aux.getFirstCode("间");
-    FCITX_ASSERT(aux.getFirstCode("不").empty());
 
     std::remove(path.c_str());
 }
@@ -164,7 +147,6 @@ int main() {
     testEmptyTable();
     testSingleCharMatch();
     testMultipleCodes();
-    testGetFirstCode();
     testMatchPhrase();
     testEmptyContent();
 

--- a/test/testauxcode.cpp
+++ b/test/testauxcode.cpp
@@ -28,34 +28,34 @@ static void testEmptyTable() {
     assert(aux.matchPhrase("时间", "om"));
 }
 
-static void testLoadAndSingleCharMatch() {
-    const std::string path = "/tmp/test_aux_code.txt";
-    writeTestTable(path, R"(# comment line
-时=oc
-间=mo
-实=bd
-践=jc
+static void testSingleCharMatch() {
+    const std::string path = "/tmp/test_aux_code_single.txt";
+    writeTestTable(path, R"(时=oc
 魔=gg
-法=ds
-少=xp
-女=va
-人=pn
-体=rb
+厑=ib
+厑=ii
 )");
 
     AuxCode aux;
     aux.loadFromFile(path);
     assert(aux.isLoaded());
 
-    // single char: any code starts with input
+    // single code: prefix match
     assert(aux.matchPhrase("时", "o"));
     assert(aux.matchPhrase("时", "oc"));
     assert(!aux.matchPhrase("时", "m"));
     assert(!aux.matchPhrase("时", "ocd"));
 
+    // single code: exact match
     assert(aux.matchPhrase("魔", "g"));
     assert(aux.matchPhrase("魔", "gg"));
     assert(!aux.matchPhrase("魔", "ggo"));
+
+    // multiple codes: any code starts with input
+    assert(aux.matchPhrase("厑", "i"));
+    assert(aux.matchPhrase("厑", "ib"));
+    assert(aux.matchPhrase("厑", "ii"));
+    assert(!aux.matchPhrase("厑", "x"));
 
     std::remove(path.c_str());
 }
@@ -71,25 +71,6 @@ static void testGetFirstCode() {
     assert(aux.getFirstCode("时") == "oc");
     assert(aux.getFirstCode("间") == "mo");
     assert(aux.getFirstCode("不").empty());
-
-    std::remove(path.c_str());
-}
-
-static void testMultiCode() {
-    const std::string path = "/tmp/test_aux_code_multi.txt";
-    writeTestTable(path, R"(厑=ib
-厑=ii
-魔=gg
-)");
-
-    AuxCode aux;
-    aux.loadFromFile(path);
-
-    // single char: any code starts with input
-    assert(aux.matchPhrase("厑", "i"));
-    assert(aux.matchPhrase("厑", "ib"));
-    assert(aux.matchPhrase("厑", "ii"));
-    assert(!aux.matchPhrase("厑", "x"));
 
     std::remove(path.c_str());
 }
@@ -215,9 +196,8 @@ A=a
 
 int main() {
     testEmptyTable();
-    testLoadAndSingleCharMatch();
+    testSingleCharMatch();
     testGetFirstCode();
-    testMultiCode();
     testMatchPhrase();
     testStrokeKeyChars();
     testBehaviorExamples();

--- a/test/testauxcode.cpp
+++ b/test/testauxcode.cpp
@@ -44,18 +44,18 @@ static void testSingleCharMatch() {
     aux.loadFromFile(path);
     FCITX_ASSERT(aux.isLoaded());
 
-    // single code: prefix match
+    // single character: prefix match
     FCITX_ASSERT(aux.matchPhrase("时", "o"));
     FCITX_ASSERT(aux.matchPhrase("时", "oc"));
     FCITX_ASSERT(!aux.matchPhrase("时", "m"));
     FCITX_ASSERT(!aux.matchPhrase("时", "ocd"));
 
-    // single code: exact match
+    // single character: boundary
     FCITX_ASSERT(aux.matchPhrase("魔", "g"));
     FCITX_ASSERT(aux.matchPhrase("魔", "gg"));
     FCITX_ASSERT(!aux.matchPhrase("魔", "ggo"));
 
-    // multiple codes: any code starts with input
+    // multiple codes per character: any code matches
     FCITX_ASSERT(aux.matchPhrase("厑", "i"));
     FCITX_ASSERT(aux.matchPhrase("厑", "ib"));
     FCITX_ASSERT(aux.matchPhrase("厑", "ii"));

--- a/test/testauxcode.cpp
+++ b/test/testauxcode.cpp
@@ -47,13 +47,15 @@ static void testLoadAndSingleCharMatch() {
     aux.loadFromFile(path);
     assert(aux.isLoaded());
 
-    // single char: inputLen must be <= 1
+    // single char: any code starts with input
     assert(aux.matchPhrase("时", "o"));
-    assert(!aux.matchPhrase("时", "oc"));
+    assert(aux.matchPhrase("时", "oc"));
     assert(!aux.matchPhrase("时", "m"));
+    assert(!aux.matchPhrase("时", "ocd"));
 
     assert(aux.matchPhrase("魔", "g"));
-    assert(!aux.matchPhrase("魔", "gg"));
+    assert(aux.matchPhrase("魔", "gg"));
+    assert(!aux.matchPhrase("魔", "ggo"));
 
     std::remove(path.c_str());
 }
@@ -83,10 +85,10 @@ static void testMultiCode() {
     AuxCode aux;
     aux.loadFromFile(path);
 
-    // single char: only one letter matches
+    // single char: any code starts with input
     assert(aux.matchPhrase("厑", "i"));
-    assert(!aux.matchPhrase("厑", "ib"));
-    assert(!aux.matchPhrase("厑", "ii"));
+    assert(aux.matchPhrase("厑", "ib"));
+    assert(aux.matchPhrase("厑", "ii"));
     assert(!aux.matchPhrase("厑", "x"));
 
     std::remove(path.c_str());
@@ -153,7 +155,8 @@ static void testStrokeKeyChars() {
     assert(aux.matchPhrase("丿", "p"));
     assert(aux.matchPhrase("㇏", "n"));
     assert(aux.matchPhrase("𠃍", "z"));
-    // single char: longer input rejected
+    // single char: prefix match
+    assert(aux.matchPhrase("一", "h"));
     assert(!aux.matchPhrase("一", "hx"));
 
     std::remove(path.c_str());

--- a/test/testauxcode.cpp
+++ b/test/testauxcode.cpp
@@ -5,8 +5,8 @@
  *
  */
 #include "auxcode.h"
-#include <fcitx-utils/log.h>
 #include <cstdio>
+#include <fcitx-utils/log.h>
 #include <fstream>
 #include <string>
 #include <unistd.h>
@@ -17,7 +17,8 @@ static std::string tempPath(const char *suffix) {
     return "/tmp/fcitx_test_aux_" + std::to_string(getpid()) + "_" + suffix;
 }
 
-static void writeTestTable(const std::string &path, const std::string &content) {
+static void writeTestTable(const std::string &path,
+                           const std::string &content) {
     std::ofstream f(path);
     f << content;
     f.close();
@@ -77,7 +78,8 @@ static void testMultipleCodes() {
     std::remove(path.c_str());
 }
 
-// Phrase matching: prefix, exact, mismatch, unmatched char, empty input, mixed content
+// Phrase matching: prefix, exact, mismatch, unmatched char, empty input, mixed
+// content
 static void testMatchPhrase() {
     auto path = tempPath("phrase");
     writeTestTable(path, R"(时=oc

--- a/test/testauxcode.cpp
+++ b/test/testauxcode.cpp
@@ -5,13 +5,17 @@
  *
  */
 #include "auxcode.h"
-#include <cassert>
+#include <fcitx-utils/log.h>
 #include <cstdio>
 #include <fstream>
-#include <iostream>
 #include <string>
+#include <unistd.h>
 
 using namespace fcitx;
+
+static std::string tempPath(const char *suffix) {
+    return "/tmp/fcitx_test_aux_" + std::to_string(getpid()) + "_" + suffix;
+}
 
 static void writeTestTable(const std::string &path, const std::string &content) {
     std::ofstream f(path);
@@ -21,15 +25,15 @@ static void writeTestTable(const std::string &path, const std::string &content) 
 
 static void testEmptyTable() {
     AuxCode aux;
-    assert(!aux.isLoaded());
+    FCITX_ASSERT(!aux.isLoaded());
     aux.loadFromFile("/nonexistent/path.txt");
-    assert(!aux.isLoaded());
-    assert(aux.getFirstCode("时").empty());
-    assert(aux.matchPhrase("时间", "om"));
+    FCITX_ASSERT(!aux.isLoaded());
+    FCITX_ASSERT(aux.getFirstCode("时").empty());
+    FCITX_ASSERT(aux.matchPhrase("时间", "om"));
 }
 
 static void testSingleCharMatch() {
-    const std::string path = "/tmp/test_aux_code_single.txt";
+    auto path = tempPath("single");
     writeTestTable(path, R"(时=oc
 魔=gg
 厑=ib
@@ -38,45 +42,45 @@ static void testSingleCharMatch() {
 
     AuxCode aux;
     aux.loadFromFile(path);
-    assert(aux.isLoaded());
+    FCITX_ASSERT(aux.isLoaded());
 
     // single code: prefix match
-    assert(aux.matchPhrase("时", "o"));
-    assert(aux.matchPhrase("时", "oc"));
-    assert(!aux.matchPhrase("时", "m"));
-    assert(!aux.matchPhrase("时", "ocd"));
+    FCITX_ASSERT(aux.matchPhrase("时", "o"));
+    FCITX_ASSERT(aux.matchPhrase("时", "oc"));
+    FCITX_ASSERT(!aux.matchPhrase("时", "m"));
+    FCITX_ASSERT(!aux.matchPhrase("时", "ocd"));
 
     // single code: exact match
-    assert(aux.matchPhrase("魔", "g"));
-    assert(aux.matchPhrase("魔", "gg"));
-    assert(!aux.matchPhrase("魔", "ggo"));
+    FCITX_ASSERT(aux.matchPhrase("魔", "g"));
+    FCITX_ASSERT(aux.matchPhrase("魔", "gg"));
+    FCITX_ASSERT(!aux.matchPhrase("魔", "ggo"));
 
     // multiple codes: any code starts with input
-    assert(aux.matchPhrase("厑", "i"));
-    assert(aux.matchPhrase("厑", "ib"));
-    assert(aux.matchPhrase("厑", "ii"));
-    assert(!aux.matchPhrase("厑", "x"));
+    FCITX_ASSERT(aux.matchPhrase("厑", "i"));
+    FCITX_ASSERT(aux.matchPhrase("厑", "ib"));
+    FCITX_ASSERT(aux.matchPhrase("厑", "ii"));
+    FCITX_ASSERT(!aux.matchPhrase("厑", "x"));
 
     std::remove(path.c_str());
 }
 
 static void testGetFirstCode() {
-    const std::string path = "/tmp/test_aux_code_first.txt";
+    auto path = tempPath("first");
     writeTestTable(path, R"(时=oc
 间=mo
 )");
 
     AuxCode aux;
     aux.loadFromFile(path);
-    assert(aux.getFirstCode("时") == "oc");
-    assert(aux.getFirstCode("间") == "mo");
-    assert(aux.getFirstCode("不").empty());
+    FCITX_ASSERT(aux.getFirstCode("时") == "oc") << aux.getFirstCode("时");
+    FCITX_ASSERT(aux.getFirstCode("间") == "mo") << aux.getFirstCode("间");
+    FCITX_ASSERT(aux.getFirstCode("不").empty());
 
     std::remove(path.c_str());
 }
 
 static void testMatchPhrase() {
-    const std::string path = "/tmp/test_aux_code_phrase.txt";
+    auto path = tempPath("phrase");
     writeTestTable(path, R"(时=oc
 间=mo
 实=bd
@@ -97,30 +101,44 @@ A=a
     aux.loadFromFile(path);
 
     // prefix match
-    assert(aux.matchPhrase("魔法少女", "g"));
-    assert(aux.matchPhrase("魔法少女", "gd"));
-    assert(aux.matchPhrase("魔法少女", "gdx"));
+    FCITX_ASSERT(aux.matchPhrase("魔法少女", "g"));
+    FCITX_ASSERT(aux.matchPhrase("魔法少女", "gd"));
+    FCITX_ASSERT(aux.matchPhrase("魔法少女", "gdx"));
 
     // exact match
-    assert(aux.matchPhrase("魔法少女", "gdxv"));
-    assert(aux.matchPhrase("人间体", "pmr"));
+    FCITX_ASSERT(aux.matchPhrase("魔法少女", "gdxv"));
+    FCITX_ASSERT(aux.matchPhrase("人间体", "pmr"));
 
     // mismatch
-    assert(!aux.matchPhrase("魔法少女", "gdxvy"));
-    assert(!aux.matchPhrase("人间体", "pmrx"));
+    FCITX_ASSERT(!aux.matchPhrase("魔法少女", "gdxvy"));
+    FCITX_ASSERT(!aux.matchPhrase("人间体", "pmrx"));
 
     // unmatched character -> filter entire phrase
-    assert(!aux.matchPhrase("没时间", "o"));
+    FCITX_ASSERT(!aux.matchPhrase("没时间", "o"));
 
     // empty input -> keep
-    assert(aux.matchPhrase("魔法少女", ""));
+    FCITX_ASSERT(aux.matchPhrase("魔法少女", ""));
 
     // multi-char codes with English
-    assert(aux.matchPhrase("多啦A梦", "d"));
-    assert(aux.matchPhrase("多啦A梦", "dk"));
-    assert(aux.matchPhrase("多啦A梦", "dka"));
-    assert(aux.matchPhrase("多啦A梦", "dkam"));
-    assert(!aux.matchPhrase("多啦A梦", "dkamx"));
+    FCITX_ASSERT(aux.matchPhrase("多啦A梦", "d"));
+    FCITX_ASSERT(aux.matchPhrase("多啦A梦", "dk"));
+    FCITX_ASSERT(aux.matchPhrase("多啦A梦", "dka"));
+    FCITX_ASSERT(aux.matchPhrase("多啦A梦", "dkam"));
+    FCITX_ASSERT(!aux.matchPhrase("多啦A梦", "dkamx"));
+
+    std::remove(path.c_str());
+}
+
+static void testEmptyContent() {
+    auto path = tempPath("empty");
+    writeTestTable(path, "# comment\n\n");
+
+    AuxCode aux;
+    aux.loadFromFile(path);
+    FCITX_ASSERT(aux.isLoaded());
+    // file opened but no entries -> matching logic runs, characters not found
+    FCITX_ASSERT(!aux.matchPhrase("时间", "o"));
+    FCITX_ASSERT(aux.matchPhrase("时间", ""));
 
     std::remove(path.c_str());
 }
@@ -130,7 +148,8 @@ int main() {
     testSingleCharMatch();
     testGetFirstCode();
     testMatchPhrase();
+    testEmptyContent();
 
-    std::cout << "All auxcode tests passed!" << std::endl;
+    FCITX_INFO() << "All auxcode tests passed!";
     return 0;
 }

--- a/test/testauxcode.cpp
+++ b/test/testauxcode.cpp
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2024
+ * SPDX-FileCopyrightText: 2026
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *

--- a/test/testauxcode.cpp
+++ b/test/testauxcode.cpp
@@ -5,43 +5,27 @@
  *
  */
 #include "auxcode.h"
-#include <cstdio>
 #include <fcitx-utils/log.h>
-#include <fstream>
+#include <sstream>
 #include <string>
-#include <unistd.h>
 
 using namespace fcitx;
 
-static std::string tempPath(const char *suffix) {
-    return "/tmp/fcitx_test_aux_" + std::to_string(getpid()) + "_" + suffix;
-}
-
-static void writeTestTable(const std::string &path,
-                           const std::string &content) {
-    std::ofstream f(path);
-    f << content;
-    f.close();
-}
-
-// File not found: isLoaded=false, matchPhrase passes through
+// Unloaded table: matchPhrase passes through
 static void testEmptyTable() {
     AuxCode aux;
-    FCITX_ASSERT(!aux.isLoaded());
-    aux.loadFromFile("/nonexistent/path.txt");
     FCITX_ASSERT(!aux.isLoaded());
     FCITX_ASSERT(aux.matchPhrase("时间", "om"));
 }
 
 // Single character: prefix match and boundary
 static void testSingleCharMatch() {
-    auto path = tempPath("single");
-    writeTestTable(path, R"(时=oc
+    std::istringstream iss(R"(时=oc
 魔=gg
 )");
 
     AuxCode aux;
-    aux.loadFromFile(path);
+    aux.loadFromStream(iss);
     FCITX_ASSERT(aux.isLoaded());
 
     // prefix match
@@ -54,19 +38,16 @@ static void testSingleCharMatch() {
     FCITX_ASSERT(aux.matchPhrase("魔", "g"));
     FCITX_ASSERT(aux.matchPhrase("魔", "gg"));
     FCITX_ASSERT(!aux.matchPhrase("魔", "ggo"));
-
-    std::remove(path.c_str());
 }
 
 // One character with multiple codes: any code matches
 static void testMultipleCodes() {
-    auto path = tempPath("multi");
-    writeTestTable(path, R"(厑=ib
+    std::istringstream iss(R"(厑=ib
 厑=ii
 )");
 
     AuxCode aux;
-    aux.loadFromFile(path);
+    aux.loadFromStream(iss);
     FCITX_ASSERT(aux.isLoaded());
 
     // any code matches
@@ -74,15 +55,12 @@ static void testMultipleCodes() {
     FCITX_ASSERT(aux.matchPhrase("厑", "ib"));
     FCITX_ASSERT(aux.matchPhrase("厑", "ii"));
     FCITX_ASSERT(!aux.matchPhrase("厑", "x"));
-
-    std::remove(path.c_str());
 }
 
 // Phrase matching: prefix, exact, mismatch, unmatched char, empty input, mixed
 // content
 static void testMatchPhrase() {
-    auto path = tempPath("phrase");
-    writeTestTable(path, R"(时=oc
+    std::istringstream iss(R"(时=oc
 间=mo
 实=bd
 践=jc
@@ -99,7 +77,7 @@ A=a
 )");
 
     AuxCode aux;
-    aux.loadFromFile(path);
+    aux.loadFromStream(iss);
 
     // prefix match
     FCITX_ASSERT(aux.matchPhrase("魔法少女", "g"));
@@ -126,23 +104,18 @@ A=a
     FCITX_ASSERT(aux.matchPhrase("多啦A梦", "dka"));
     FCITX_ASSERT(aux.matchPhrase("多啦A梦", "dkam"));
     FCITX_ASSERT(!aux.matchPhrase("多啦A梦", "dkamx"));
-
-    std::remove(path.c_str());
 }
 
-// File opened but no valid entries
+// Loaded table with no valid entries
 static void testEmptyContent() {
-    auto path = tempPath("empty");
-    writeTestTable(path, "# comment\n\n");
+    std::istringstream iss("# comment\n\n");
 
     AuxCode aux;
-    aux.loadFromFile(path);
+    aux.loadFromStream(iss);
     FCITX_ASSERT(aux.isLoaded());
-    // file opened but no entries -> matching logic runs, characters not found
+    // table loaded but no entries -> matching logic runs, characters not found
     FCITX_ASSERT(!aux.matchPhrase("时间", "o"));
     FCITX_ASSERT(aux.matchPhrase("时间", ""));
-
-    std::remove(path.c_str());
 }
 
 int main() {

--- a/test/testauxcode.cpp
+++ b/test/testauxcode.cpp
@@ -36,7 +36,29 @@ static void testSingleCharMatch() {
     auto path = tempPath("single");
     writeTestTable(path, R"(时=oc
 魔=gg
-厑=ib
+)");
+
+    AuxCode aux;
+    aux.loadFromFile(path);
+    FCITX_ASSERT(aux.isLoaded());
+
+    // prefix match
+    FCITX_ASSERT(aux.matchPhrase("时", "o"));
+    FCITX_ASSERT(aux.matchPhrase("时", "oc"));
+    FCITX_ASSERT(!aux.matchPhrase("时", "m"));
+    FCITX_ASSERT(!aux.matchPhrase("时", "ocd"));
+
+    // boundary
+    FCITX_ASSERT(aux.matchPhrase("魔", "g"));
+    FCITX_ASSERT(aux.matchPhrase("魔", "gg"));
+    FCITX_ASSERT(!aux.matchPhrase("魔", "ggo"));
+
+    std::remove(path.c_str());
+}
+
+static void testMultipleCodes() {
+    auto path = tempPath("multi");
+    writeTestTable(path, R"(厑=ib
 厑=ii
 )");
 
@@ -44,18 +66,7 @@ static void testSingleCharMatch() {
     aux.loadFromFile(path);
     FCITX_ASSERT(aux.isLoaded());
 
-    // single character: prefix match
-    FCITX_ASSERT(aux.matchPhrase("时", "o"));
-    FCITX_ASSERT(aux.matchPhrase("时", "oc"));
-    FCITX_ASSERT(!aux.matchPhrase("时", "m"));
-    FCITX_ASSERT(!aux.matchPhrase("时", "ocd"));
-
-    // single character: boundary
-    FCITX_ASSERT(aux.matchPhrase("魔", "g"));
-    FCITX_ASSERT(aux.matchPhrase("魔", "gg"));
-    FCITX_ASSERT(!aux.matchPhrase("魔", "ggo"));
-
-    // multiple codes per character: any code matches
+    // any code matches
     FCITX_ASSERT(aux.matchPhrase("厑", "i"));
     FCITX_ASSERT(aux.matchPhrase("厑", "ib"));
     FCITX_ASSERT(aux.matchPhrase("厑", "ii"));
@@ -146,6 +157,7 @@ static void testEmptyContent() {
 int main() {
     testEmptyTable();
     testSingleCharMatch();
+    testMultipleCodes();
     testGetFirstCode();
     testMatchPhrase();
     testEmptyContent();


### PR DESCRIPTION
### 功能说明

为拼音输入法添加辅助码筛选功能。用户在输入拼音后，可通过触发键进入辅助码模式，输入辅助码来过滤候选词。

目前功能已经可用，但存在一些问题，因此这个 PR 只能作为 Demo。

### 当前实现

1. **码表加载**
   - 从 `~/.local/share/fcitx5/pinyin/auxcode/` 加载文本格式码表（如`flypy_full.txt`）
   - 格式参考 [rime-lua-aux-code](https://github.com/HowcanoeWang/rime-lua-aux-code) （与手心输入法格式相同）
   - 每行一字，同一字可有多个辅码，辅码长度不限
   ```
   人=pn
   间=mo
   体=rb
   A=a
   ```

2. **触发方式**
   - 通过触发键进入辅码筛选模式（如 `Tab`）
   - 默认未设置触发键
   - 触发键可与翻页键相同（如均为 `Tab`）

3. **匹配规则**
   - **单字**：完整匹配辅码。例：`人` 匹配 `p` 或 `pn`
   - **词组**：依次匹配每个字的首位辅码，N字词辅码长度为 N。例：`人间` 匹配 `pm`，`人间体` 匹配 `pmr`
   - 此行为与拼音加加一致，但与 fcitx5 现有笔画筛选及 rime-lua-aux-code 不同

4. **交互方式**
   - 辅码模式下支持连续输入、连续筛选，直至用户手动退出

### 已知问题

1. **与笔画筛选功能重叠**（最严重的问题）
   - 笔画筛选已用于多个场景（如 fcitx5-android）
   - 笔画筛选支持辅助码不涉及的功能（如将笔画显示为 `一丨丿㇏𠃍`）
   - 若两者合并，需考虑移动端虚拟键盘与实体键盘的不同使用场景（比如，在虚拟键盘只用笔画筛选，连接实体键盘后使用辅助码）

2. **码表格式限制**
   - 当前仅支持单个文本码表，未使用 fcitx5 二进制格式
   - 理想方案：支持多码表加载，允许用户按需选择
   - 可参考搜狗输入法，同时支持笔画和拆字

3. **词组筛选模式单一**
   - 当前仅支持每字首码这一种模式
   - 可能需要增加选项，允许使用词中任意字的辅助码进行匹配

### 其他尝试

我试过实现直接辅码（无需触发键），但存在技术问题未解决，暂不包含在此 PR 中。
好在这并不是常用功能。

### 相关 Issue

- #276
- #130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added auxiliary-code filtering for Pinyin candidate selection.
  - Supports configurable auxiliary-code profiles and trigger keys.
  - Allows Latin-letter input with backspace, Escape, and page navigation.
  - Supports matching auxiliary codes against individual characters and phrases.
  - Auxiliary-code state resets after selection, empty input, or standard reset actions.

- **Tests**
  - Added coverage for auxiliary-code loading, matching, boundaries, invalid data, and mixed text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->