### PR TITLE
use nlohmann/json to parse cloudpinyin result

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ option(ENABLE_TOOLS "Build tools" On)
 
 if (ENABLE_OPENCC)
     find_package(OpenCC 1.0.1 REQUIRED)
+endif()
+if (ENABLE_OPENCC OR ENABLE_CLOUDPINYIN)
     find_package(nlohmann_json 3.2 REQUIRED)
 endif()
 

--- a/modules/chttrans/chttrans.cpp
+++ b/modules/chttrans/chttrans.cpp
@@ -271,7 +271,7 @@ const Configuration *Chttrans::getConfig() const {
         try {
             std::ifstream in(file.second, std::ios::in | std::ios::binary);
             std::string strBuf(std::istreambuf_iterator<char>(in), {});
-            auto jv = nlohmann::json::parse(strBuf);
+            const auto jv = nlohmann::json::parse(strBuf);
             auto name = jv.at("name").get<std::string>();
             std::string description = file.first.stem();
             if (!name.empty()) {

--- a/modules/cloudpinyin/CMakeLists.txt
+++ b/modules/cloudpinyin/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CLOUDPINYIN_SOURCES
 
 if (ENABLE_CLOUDPINYIN)
 add_fcitx5_addon(cloudpinyin ${CLOUDPINYIN_SOURCES})
-target_link_libraries(cloudpinyin Fcitx5::Core Fcitx5::Config PkgConfig::Curl Pthread::Pthread)
+target_link_libraries(cloudpinyin Fcitx5::Core Fcitx5::Config PkgConfig::Curl Pthread::Pthread nlohmann_json::nlohmann_json)
 install(TARGETS cloudpinyin DESTINATION "${CMAKE_INSTALL_LIBDIR}/fcitx5")
 configure_file(cloudpinyin.conf.in.in cloudpinyin.conf.in)
 fcitx5_translate_desktop_file("${CMAKE_CURRENT_BINARY_DIR}/cloudpinyin.conf.in" cloudpinyin.conf)

--- a/modules/cloudpinyin/cloudpinyin.cpp
+++ b/modules/cloudpinyin/cloudpinyin.cpp
@@ -24,6 +24,7 @@
 #include <fcitx/addonmanager.h>
 #include <fcntl.h>
 #include <memory>
+#include <nlohmann/json.hpp>
 #include <string>
 #include <string_view>
 #include <unistd.h>
@@ -55,16 +56,12 @@ public:
         const std::string_view result(queue->result().data(),
                                       queue->result().size());
         CLOUDPINYIN_DEBUG() << "Request result: " << result;
-        auto start = result.find("\",[\"");
-        std::string hanzi;
-        if (start != std::string_view::npos) {
-            start += strlen("\",[\"");
-            auto end = result.find('\"', start);
-            if (end != std::string_view::npos && end > start) {
-                hanzi = result.substr(start, end - start);
-            }
+        try {
+            auto jv = nlohmann::json::parse(result);
+            return jv[1][0][1][0].get<std::string>();
+        } catch (const std::exception &) {
+            return {};
         }
-        return hanzi;
     }
 
 private:
@@ -92,16 +89,12 @@ public:
         const std::string_view result(queue->result().data(),
                                       queue->result().size());
         CLOUDPINYIN_DEBUG() << "Request result: " << result;
-        auto start = result.find("[[\"");
-        std::string hanzi;
-        if (start != std::string::npos) {
-            start += strlen("[[\"");
-            auto end = result.find("\",", start);
-            if (end != std::string::npos && end > start) {
-                hanzi = result.substr(start, end - start);
-            }
+        try {
+            auto jv = nlohmann::json::parse(result);
+            return jv["result"][0][0][0].get<std::string>();
+        } catch (const std::exception &) {
+            return {};
         }
-        return hanzi;
     }
 };
 

--- a/modules/cloudpinyin/cloudpinyin.cpp
+++ b/modules/cloudpinyin/cloudpinyin.cpp
@@ -57,7 +57,7 @@ public:
                                       queue->result().size());
         CLOUDPINYIN_DEBUG() << "Request result: " << result;
         try {
-            auto jv = nlohmann::json::parse(result);
+            const auto jv = nlohmann::json::parse(result);
             return jv[1][0][1][0].get<std::string>();
         } catch (const std::exception &) {
             return {};
@@ -90,7 +90,7 @@ public:
                                       queue->result().size());
         CLOUDPINYIN_DEBUG() << "Request result: " << result;
         try {
-            auto jv = nlohmann::json::parse(result);
+            const auto jv = nlohmann::json::parse(result);
             return jv["result"][0][0][0].get<std::string>();
         } catch (const std::exception &) {
             return {};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cloud Pinyin handling for Google and Baidu responses with more reliable structured data parsing.
  * Invalid or unexpected responses now fail gracefully and return no result instead of causing parsing issues.
  * Improved consistency when loading conversion profiles.
* **Build Improvements**
  * Cloud Pinyin builds now automatically include the required JSON support when the feature is enabled.
  * OpenCC and Cloud Pinyin options now correctly provide their required build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->