### PR TITLE
fix crash on empty result

### DIFF
--- a/modules/cloudpinyin/cloudpinyin.cpp
+++ b/modules/cloudpinyin/cloudpinyin.cpp
@@ -52,13 +52,10 @@ public:
         return (curl_easy_setopt(queue->curl(), CURLOPT_URL, url.c_str()) ==
                 CURLE_OK);
     }
-    std::string parseResult(CurlQueue *queue) override {
-        const std::string_view result(queue->result().data(),
-                                      queue->result().size());
-        CLOUDPINYIN_DEBUG() << "Request result: " << result;
+    std::string parseResult(std::string_view result) override {
         try {
             const auto jv = nlohmann::json::parse(result);
-            return jv[1][0][1][0].get<std::string>();
+            return jv.at(1).at(0).at(1).at(0).get<std::string>();
         } catch (const std::exception &) {
             return {};
         }
@@ -85,13 +82,13 @@ public:
                 CURLE_OK);
     }
 
-    std::string parseResult(CurlQueue *queue) override {
-        const std::string_view result(queue->result().data(),
-                                      queue->result().size());
-        CLOUDPINYIN_DEBUG() << "Request result: " << result;
+    std::string parseResult(std::string_view result) override {
         try {
             const auto jv = nlohmann::json::parse(result);
-            return jv["result"][0][0][0].get<std::string>();
+            if (jv.at("status") != "T" || jv.at("errno") != "0") {
+                return {};
+            }
+            return jv.at("result").at(0).at(0).at(0).get<std::string>();
         } catch (const std::exception &) {
             return {};
         }
@@ -199,7 +196,10 @@ void CloudPinyin::notifyFinished() {
 
             std::string hanzi;
             if (b) {
-                hanzi = b->parseResult(item);
+                const std::string_view result(item->result().data(),
+                                              item->result().size());
+                CLOUDPINYIN_DEBUG() << "Request result: " << result;
+                hanzi = b->parseResult(result);
             } else {
                 hanzi = "";
             }

--- a/modules/cloudpinyin/cloudpinyin.h
+++ b/modules/cloudpinyin/cloudpinyin.h
@@ -20,6 +20,7 @@
 #include <fcitx/addonfactory.h>
 #include <fcitx/addoninstance.h>
 #include <fcitx/instance.h>
+#include <string_view>
 
 FCITX_CONFIG_ENUM(CloudPinyinBackend, Google, GoogleCN, Baidu);
 FCITX_CONFIGURATION(
@@ -48,7 +49,7 @@ class Backend {
 public:
     FCITX_NODISCARD virtual bool prepareRequest(CurlQueue *queue,
                                                 const std::string &pinyin) = 0;
-    virtual std::string parseResult(CurlQueue *queue) = 0;
+    virtual std::string parseResult(std::string_view result) = 0;
     virtual ~Backend() = default;
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,9 +7,13 @@ add_dependencies(testpunctuation punctuation punctuation.conf.in-fmt)
 add_test(NAME testpunctuation COMMAND testpunctuation)
 
 if (ENABLE_CLOUDPINYIN)
-add_executable(testcloudpinyin testcloudpinyin.cpp)
-target_link_libraries(testcloudpinyin Fcitx5::Core Fcitx5::Module::CloudPinyin)
+add_executable(testcloudpinyin testcloudpinyin.cpp
+                              ../modules/cloudpinyin/fetch.cpp)
+target_link_libraries(testcloudpinyin
+    Fcitx5::Core Fcitx5::Config Fcitx5::Module::CloudPinyin PkgConfig::Curl
+    Pthread::Pthread nlohmann_json::nlohmann_json)
 add_dependencies(testcloudpinyin cloudpinyin copy-addon-cloudpinyin)
+add_test(NAME testcloudpinyin COMMAND testcloudpinyin)
 endif()
 
 add_executable(testpinyinhelper testpinyinhelper.cpp)

--- a/test/testcloudpinyin.cpp
+++ b/test/testcloudpinyin.cpp
@@ -4,9 +4,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
  */
-#include "cloudpinyin_public.h"
+#include "../modules/cloudpinyin/cloudpinyin.cpp"
 #include "testdir.h"
-#include <cassert>
 #include <fcitx-config/rawconfig.h>
 #include <fcitx-utils/event.h>
 #include <fcitx-utils/log.h>
@@ -17,7 +16,24 @@
 #include <fcitx/instance.h>
 #include <string>
 
+void testBaiduResult() {
+    BaiduBackend backend;
+
+    const auto normalResult = backend.parseResult(
+        R"({"status":"T","errno":"0","errmsg":"","result":[[["结果",6,{"pinyin":"jie'guo","type":"IMEDICT"}]]]})");
+    FCITX_ASSERT(normalResult == "结果");
+
+    const auto errorResult = backend.parseResult(
+        R"({"status":"F","errno":"3","errmsg":"","result":[]})");
+    FCITX_ASSERT(errorResult.empty());
+
+    const auto invalidResult = backend.parseResult("invalid json");
+    FCITX_ASSERT(invalidResult.empty());
+}
+
 int main() {
+    testBaiduResult();
+
     fcitx::setupTestingEnvironment(TESTING_BINARY_DIR, {"bin"},
                                    {"test", TESTING_SOURCE_DIR "/modules"});
     fcitx::Log::setLogRule("*=5");


### PR DESCRIPTION
https://github.com/fcitx/fcitx5-macos/issues/416
Refactor `parseResult` for simplicity and ease of unit test.
Also fix cmake that test was not ran on CI.
P.S. `auto jv` instead of `const auto jv` would survive `[]` 😂

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cloud Pinyin response handling for missing, malformed, or invalid data.
  * Invalid Baidu responses are now rejected instead of being processed, improving result reliability.
  * Unexpected response errors are handled gracefully without disrupting the application.

* **Tests**
  * Expanded Cloud Pinyin coverage for successful responses, service errors, and invalid JSON.
  * Cloud Pinyin tests are now integrated with the standard test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->