### PR TITLE
Split backend to its own file and split the test

### DIFF
--- a/modules/cloudpinyin/CMakeLists.txt
+++ b/modules/cloudpinyin/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(CLOUDPINYIN_SOURCES
+    backend.cpp
     cloudpinyin.cpp
     fetch.cpp
 )

--- a/modules/cloudpinyin/backend.cpp
+++ b/modules/cloudpinyin/backend.cpp
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2017 CSSlayer <wengxt@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ */
+
+#include "backend.h"
+#include <curl/curl.h>
+#include <exception>
+#include <fcitx-utils/misc.h>
+#include <fcitx-utils/stringutils.h>
+#include <format>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace fcitx::cloudpinyin {
+
+namespace {
+
+class GoogleBackend : public Backend {
+public:
+    explicit GoogleBackend(std::string url) : url_(std::move(url)) {}
+
+    std::string prepareRequest(const std::string &pinyin) override {
+        const UniqueCPtr<char, curl_free> escaped(
+            curl_escape(pinyin.c_str(), static_cast<int>(pinyin.size())));
+        if (!escaped) {
+            return {};
+        }
+        const std::string url = stringutils::concat(url_, escaped.get());
+        return url;
+    }
+
+    std::string parseResult(std::string_view result) override {
+        try {
+            const auto jv = nlohmann::json::parse(result);
+            return jv.at(1).at(0).at(1).at(0).get<std::string>();
+        } catch (const std::exception &) {
+            return {};
+        }
+    }
+
+private:
+    const std::string url_;
+};
+
+class BaiduBackend : public Backend {
+public:
+    std::string prepareRequest(const std::string &pinyin) override {
+        const UniqueCPtr<char, &curl_free> escaped(
+            curl_escape(pinyin.c_str(), static_cast<int>(pinyin.size())));
+        if (!escaped) {
+            return {};
+        }
+        const std::string url =
+            std::format("https://olimenew.baidu.com/"
+                        "py?input={}&inputtype=py&resultcoding=utf-8",
+                        escaped.get());
+        return url;
+    }
+
+    std::string parseResult(std::string_view result) override {
+        try {
+            const auto jv = nlohmann::json::parse(result);
+            if (jv.at("status") != "T" || jv.at("errno") != "0") {
+                return {};
+            }
+            return jv.at("result").at(0).at(0).at(0).get<std::string>();
+        } catch (const std::exception &) {
+            return {};
+        }
+    }
+};
+
+} // namespace
+
+std::unique_ptr<Backend> createBackend(CloudPinyinBackend backend) {
+    switch (backend) {
+    case CloudPinyinBackend::Google:
+        return std::make_unique<GoogleBackend>(
+            "https://www.google.com/inputtools/request?ime=pinyin&text=");
+    case CloudPinyinBackend::GoogleCN:
+        return std::make_unique<GoogleBackend>(
+            "https://www.google.cn/inputtools/request?ime=pinyin&text=");
+    case CloudPinyinBackend::Baidu:
+        return std::make_unique<BaiduBackend>();
+    }
+    return std::make_unique<GoogleBackend>(
+        "https://www.google.cn/inputtools/request?ime=pinyin&text=");
+}
+
+} // namespace fcitx::cloudpinyin

--- a/modules/cloudpinyin/backend.h
+++ b/modules/cloudpinyin/backend.h
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: 2017-2017 CSSlayer <wengxt@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ */
+#ifndef _CLOUDPINYIN_BACKEND_H_
+#define _CLOUDPINYIN_BACKEND_H_
+
+#include <fcitx-config/enum.h>
+#include <fcitx-utils/macros.h>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace fcitx::cloudpinyin {
+
+FCITX_CONFIG_ENUM(CloudPinyinBackend, Google, GoogleCN, Baidu);
+
+class Backend {
+public:
+    FCITX_NODISCARD virtual std::string
+    prepareRequest(const std::string &pinyin) = 0;
+    virtual std::string parseResult(std::string_view result) = 0;
+    virtual ~Backend() = default;
+};
+
+std::unique_ptr<Backend> createBackend(CloudPinyinBackend backend);
+
+} // namespace fcitx::cloudpinyin
+
+#endif // _CLOUDPINYIN_BACKEND_H_

--- a/modules/cloudpinyin/cloudpinyin.cpp
+++ b/modules/cloudpinyin/cloudpinyin.cpp
@@ -6,10 +6,10 @@
  */
 
 #include "cloudpinyin.h"
+#include "backend.h"
 #include "cloudpinyin_public.h"
 #include "fetch.h"
 #include <cstdint>
-#include <cstring>
 #include <curl/curl.h>
 #include <fcitx-config/iniparser.h>
 #include <fcitx-utils/eventloopinterface.h>
@@ -24,76 +24,16 @@
 #include <fcitx/addonmanager.h>
 #include <fcntl.h>
 #include <memory>
-#include <nlohmann/json.hpp>
 #include <string>
 #include <string_view>
 #include <unistd.h>
-#include <utility>
 
-using namespace fcitx;
+namespace fcitx::cloudpinyin {
 
 namespace {
 
 #define CLOUDPINYIN_DEBUG() FCITX_LOGC(cloudpinyin, Debug)
 FCITX_DEFINE_LOG_CATEGORY(cloudpinyin, "cloudpinyin");
-
-class GoogleBackend : public Backend {
-public:
-    GoogleBackend(std::string url) : url_(std::move(url)) {}
-
-    bool prepareRequest(CurlQueue *queue, const std::string &pinyin) override {
-        const UniqueCPtr<char, curl_free> escaped(
-            curl_escape(pinyin.c_str(), static_cast<int>(pinyin.size())));
-        if (!escaped) {
-            return false;
-        }
-        const std::string url = stringutils::concat(url_, escaped.get());
-        CLOUDPINYIN_DEBUG() << "Request URL: " << url;
-        return (curl_easy_setopt(queue->curl(), CURLOPT_URL, url.c_str()) ==
-                CURLE_OK);
-    }
-    std::string parseResult(std::string_view result) override {
-        try {
-            const auto jv = nlohmann::json::parse(result);
-            return jv.at(1).at(0).at(1).at(0).get<std::string>();
-        } catch (const std::exception &) {
-            return {};
-        }
-    }
-
-private:
-    const std::string url_;
-};
-
-class BaiduBackend : public Backend {
-public:
-    bool prepareRequest(CurlQueue *queue, const std::string &pinyin) override {
-        const UniqueCPtr<char, &curl_free> escaped(
-            curl_escape(pinyin.c_str(), static_cast<int>(pinyin.size())));
-        if (!escaped) {
-            return false;
-        }
-        const std::string url =
-            std::format("https://olimenew.baidu.com/"
-                        "py?input={}&inputtype=py&resultcoding=utf-8",
-                        escaped.get());
-        CLOUDPINYIN_DEBUG() << "Request URL: " << url;
-        return (curl_easy_setopt(queue->curl(), CURLOPT_URL, url.c_str()) ==
-                CURLE_OK);
-    }
-
-    std::string parseResult(std::string_view result) override {
-        try {
-            const auto jv = nlohmann::json::parse(result);
-            if (jv.at("status") != "T" || jv.at("errno") != "0") {
-                return {};
-            }
-            return jv.at("result").at(0).at(0).at(0).get<std::string>();
-        } catch (const std::exception &) {
-            return {};
-        }
-    }
-};
 
 constexpr int MAX_ERROR = 10;
 constexpr uint64_t minInUs = 60000000;
@@ -105,16 +45,12 @@ CloudPinyin::CloudPinyin(fcitx::AddonManager *manager)
       dispatcher_(manager->instance()->eventDispatcher()) {
     curl_global_init(CURL_GLOBAL_ALL);
 
-    backends_.emplace(
-        CloudPinyinBackend::Google,
-        std::make_unique<GoogleBackend>(
-            "https://www.google.com/inputtools/request?ime=pinyin&text="));
-    backends_.emplace(
-        CloudPinyinBackend::GoogleCN,
-        std::make_unique<GoogleBackend>(
-            "https://www.google.cn/inputtools/request?ime=pinyin&text="));
+    backends_.emplace(CloudPinyinBackend::Google,
+                      createBackend(CloudPinyinBackend::Google));
+    backends_.emplace(CloudPinyinBackend::GoogleCN,
+                      createBackend(CloudPinyinBackend::GoogleCN));
     backends_.emplace(CloudPinyinBackend::Baidu,
-                      std::make_unique<BaiduBackend>());
+                      createBackend(CloudPinyinBackend::Baidu));
 
     resetError_ =
         eventLoop_->addTimeEvent(CLOCK_MONOTONIC, now(CLOCK_MONOTONIC), minInUs,
@@ -154,7 +90,13 @@ void CloudPinyin::request(const std::string &pinyin,
         auto *b = iter->second.get();
         if (!thread_->addRequest([proxy = *config_.proxy, b, &pinyin,
                                   &callback](CurlQueue *queue) {
-                if (!b->prepareRequest(queue, pinyin)) {
+                const auto url = b->prepareRequest(pinyin);
+                if (url.empty()) {
+                    return false;
+                }
+                CLOUDPINYIN_DEBUG() << "Request URL: " << url;
+                if (curl_easy_setopt(queue->curl(), CURLOPT_URL, url.c_str()) !=
+                    CURLE_OK) {
                     return false;
                 }
                 if (curl_easy_setopt(
@@ -214,3 +156,5 @@ void CloudPinyin::notifyFinished() {
 }
 
 FCITX_ADDON_FACTORY_V2(cloudpinyin, CloudPinyinFactory);
+
+} // namespace fcitx::cloudpinyin

--- a/modules/cloudpinyin/cloudpinyin.h
+++ b/modules/cloudpinyin/cloudpinyin.h
@@ -7,22 +7,30 @@
 #ifndef _CLOUDPINYIN_CLOUDPINYIN_H_
 #define _CLOUDPINYIN_CLOUDPINYIN_H_
 
+#include "backend.h"
 #include "cloudpinyin_public.h"
 #include "fetch.h"
 #include "lrucache.h"
 #include <fcitx-config/configuration.h>
 #include <fcitx-config/enum.h>
 #include <fcitx-config/iniparser.h>
+#include <fcitx-config/option.h>
+#include <fcitx-config/rawconfig.h>
 #include <fcitx-utils/eventdispatcher.h>
+#include <fcitx-utils/eventloopinterface.h>
 #include <fcitx-utils/i18n.h>
+#include <fcitx-utils/key.h>
 #include <fcitx-utils/misc.h>
 #include <fcitx-utils/trackableobject.h>
 #include <fcitx/addonfactory.h>
 #include <fcitx/addoninstance.h>
 #include <fcitx/instance.h>
-#include <string_view>
+#include <memory>
+#include <string>
+#include <unordered_map>
 
-FCITX_CONFIG_ENUM(CloudPinyinBackend, Google, GoogleCN, Baidu);
+namespace fcitx::cloudpinyin {
+
 FCITX_CONFIGURATION(
     CloudPinyinConfig,
     fcitx::Option<fcitx::KeyList> toggleKey{
@@ -44,14 +52,6 @@ FCITX_CONFIGURATION(
         {_("The proxy format must be the one that is supported by cURL. "
            "Usually it is in the format of [scheme]://[host]:[port], e.g. "
            "http://localhost:1080.")}};);
-
-class Backend {
-public:
-    FCITX_NODISCARD virtual bool prepareRequest(CurlQueue *queue,
-                                                const std::string &pinyin) = 0;
-    virtual std::string parseResult(std::string_view result) = 0;
-    virtual ~Backend() = default;
-};
 
 class CloudPinyin : public fcitx::AddonInstance,
                     public fcitx::TrackableObject<CloudPinyin> {
@@ -100,5 +100,7 @@ public:
         return new CloudPinyin(manager);
     }
 };
+
+} // namespace fcitx::cloudpinyin
 
 #endif // _CLOUDPINYIN_CLOUDPINYIN_H_

--- a/modules/cloudpinyin/fetch.cpp
+++ b/modules/cloudpinyin/fetch.cpp
@@ -20,7 +20,7 @@
 #include <thread>
 #include <unistd.h>
 
-using namespace fcitx;
+namespace fcitx::cloudpinyin {
 
 FetchThread::FetchThread(CloudPinyin *cloudPinyin) : cloudPinyin_(cloudPinyin) {
     curlm_ = curl_multi_init();
@@ -247,3 +247,5 @@ void FetchThread::run() {
     events_.clear();
     loop_.reset();
 }
+
+} // namespace fcitx::cloudpinyin

--- a/modules/cloudpinyin/fetch.h
+++ b/modules/cloudpinyin/fetch.h
@@ -31,6 +31,8 @@
 #define MAX_HANDLE 100l
 #define MAX_BUFFER_SIZE 2048
 
+namespace fcitx::cloudpinyin {
+
 class CloudPinyin;
 
 class CurlQueue : public fcitx::IntrusiveListNode {
@@ -182,5 +184,7 @@ private:
     std::mutex pendingQueueLock;
     std::mutex finishQueueLock;
 };
+
+} // namespace fcitx::cloudpinyin
 
 #endif // _CLOUDPINYIN_FETCH_H_

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,13 +7,15 @@ add_dependencies(testpunctuation punctuation punctuation.conf.in-fmt)
 add_test(NAME testpunctuation COMMAND testpunctuation)
 
 if (ENABLE_CLOUDPINYIN)
-add_executable(testcloudpinyin testcloudpinyin.cpp
-                              ../modules/cloudpinyin/fetch.cpp)
+add_executable(testcloudpinyinbackend testcloudpinyinbackend.cpp ../modules/cloudpinyin/backend.cpp)
+target_include_directories(testcloudpinyinbackend PRIVATE ${PROJECT_SOURCE_DIR}/modules/cloudpinyin PkgConfig::Curl)
+target_link_libraries(testcloudpinyinbackend Fcitx5::Core nlohmann_json::nlohmann_json PkgConfig::Curl)
+add_test(NAME testcloudpinyinbackend COMMAND testcloudpinyinbackend)
+
+add_executable(testcloudpinyin testcloudpinyin.cpp)
 target_link_libraries(testcloudpinyin
-    Fcitx5::Core Fcitx5::Config Fcitx5::Module::CloudPinyin PkgConfig::Curl
-    Pthread::Pthread nlohmann_json::nlohmann_json)
+    Fcitx5::Core Fcitx5::Config Fcitx5::Module::CloudPinyin)
 add_dependencies(testcloudpinyin cloudpinyin copy-addon-cloudpinyin)
-add_test(NAME testcloudpinyin COMMAND testcloudpinyin)
 endif()
 
 add_executable(testpinyinhelper testpinyinhelper.cpp)

--- a/test/testcloudpinyin.cpp
+++ b/test/testcloudpinyin.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  *
  */
-#include "../modules/cloudpinyin/cloudpinyin.cpp"
+#include "cloudpinyin_public.h"
 #include "testdir.h"
 #include <fcitx-config/rawconfig.h>
 #include <fcitx-utils/event.h>
@@ -16,24 +16,7 @@
 #include <fcitx/instance.h>
 #include <string>
 
-void testBaiduResult() {
-    BaiduBackend backend;
-
-    const auto normalResult = backend.parseResult(
-        R"({"status":"T","errno":"0","errmsg":"","result":[[["结果",6,{"pinyin":"jie'guo","type":"IMEDICT"}]]]})");
-    FCITX_ASSERT(normalResult == "结果");
-
-    const auto errorResult = backend.parseResult(
-        R"({"status":"F","errno":"3","errmsg":"","result":[]})");
-    FCITX_ASSERT(errorResult.empty());
-
-    const auto invalidResult = backend.parseResult("invalid json");
-    FCITX_ASSERT(invalidResult.empty());
-}
-
 int main() {
-    testBaiduResult();
-
     fcitx::setupTestingEnvironment(TESTING_BINARY_DIR, {"bin"},
                                    {"test", TESTING_SOURCE_DIR "/modules"});
     fcitx::Log::setLogRule("*=5");

--- a/test/testcloudpinyinbackend.cpp
+++ b/test/testcloudpinyinbackend.cpp
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: 2026-2026 CSSlayer <wengxt@gmail.com>
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ *
+ */
+#include "backend.h"
+#include <fcitx-utils/log.h>
+
+using namespace fcitx::cloudpinyin;
+
+namespace {
+
+void testGooglePrepareRequest() {
+    auto google = createBackend(CloudPinyinBackend::Google);
+    auto googleCN = createBackend(CloudPinyinBackend::GoogleCN);
+
+    FCITX_ASSERT(
+        google->prepareRequest("nihao") ==
+        "https://www.google.com/inputtools/request?ime=pinyin&text=nihao");
+    FCITX_ASSERT(
+        googleCN->prepareRequest("nihao") ==
+        "https://www.google.cn/inputtools/request?ime=pinyin&text=nihao");
+}
+
+void testGoogleResult() {
+    auto backend = createBackend(CloudPinyinBackend::Google);
+
+    const auto normalResult = backend->parseResult(
+        R"(["SUCCESS",[["nihao",["你好"],[],{"annotation":["ni hao"],"candidate_type":[0],"lc":["16 16"]}]]])");
+    FCITX_ASSERT(normalResult == "你好");
+
+    const auto errorResult =
+        backend->parseResult(R"(["FAILED_TO_PARSE_REQUEST_BODY"])");
+    FCITX_ASSERT(errorResult.empty());
+
+    const auto invalidResult = backend->parseResult("invalid json");
+    FCITX_ASSERT(invalidResult.empty());
+
+    const auto invalidResult2 = backend->parseResult("");
+    FCITX_ASSERT(invalidResult2.empty());
+}
+
+void testBaiduPrepareRequest() {
+    auto backend = createBackend(CloudPinyinBackend::Baidu);
+
+    FCITX_ASSERT(backend->prepareRequest("nihao") ==
+                 "https://olimenew.baidu.com/"
+                 "py?input=nihao&inputtype=py&resultcoding=utf-8");
+}
+
+void testBaiduResult() {
+    auto backend = createBackend(CloudPinyinBackend::Baidu);
+
+    const auto normalResult = backend->parseResult(
+        R"({"status":"T","errno":"0","errmsg":"","result":[[["结果",6,{"pinyin":"jie'guo","type":"IMEDICT"}]]]})");
+    FCITX_ASSERT(normalResult == "结果");
+
+    const auto errorResult = backend->parseResult(
+        R"({"status":"F","errno":"3","errmsg":"","result":[]})");
+    FCITX_ASSERT(errorResult.empty());
+
+    const auto invalidResult = backend->parseResult("invalid json");
+    FCITX_ASSERT(invalidResult.empty());
+
+    const auto invalidResult2 = backend->parseResult("");
+    FCITX_ASSERT(invalidResult2.empty());
+}
+
+} // namespace
+
+int main() {
+    testGooglePrepareRequest();
+    testGoogleResult();
+    testBaiduPrepareRequest();
+    testBaiduResult();
+    return 0;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Google, Google China, and Baidu cloud Pinyin backends.
  * Cloud Pinyin requests now handle input encoding and provider-specific response formats.
* **Bug Fixes**
  * Improved handling of invalid, empty, or unsuccessful provider responses by safely returning no suggestions.
  * Added Google China fallback behavior when selecting a cloud Pinyin backend.
* **Tests**
  * Added coverage for backend selection, request generation, successful parsing, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->