### PR TITLE
fix stroke filter on prediction

### DIFF
--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -1714,13 +1714,17 @@ bool PinyinEngine::isStrokeFilterActive(InputContext *inputContext) const {
 }
 
 bool PinyinEngine::startStrokeFilter(InputContext *inputContext) {
+    auto *state = inputContext->propertyFor(&factory_);
+    if (state->predictWords_) {
+        return false;
+    }
+
     auto candidateList = inputContext->inputPanel().candidateList();
     if (!candidateList || candidateList->empty() || !candidateList->toBulk() ||
         !pinyinhelper()) {
         return false;
     }
 
-    auto *state = inputContext->propertyFor(&factory_);
     resetStroke(inputContext);
     state->strokeCandidateList_ = candidateList;
     updateFilter(inputContext);

--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -519,9 +519,6 @@ void PinyinEngine::updatePuncCandidate(
 
 void PinyinEngine::updateUI(InputContext *inputContext) {
     auto *state = inputContext->propertyFor(&factory_);
-    if (state->mode_ == PinyinMode::StrokeFilter) {
-        resetStroke(inputContext);
-    }
     inputContext->inputPanel().reset();
     // Use const ref to avoid accidentally change anything.
     const auto &context = state->context_;
@@ -1597,10 +1594,11 @@ bool PinyinEngine::handleNextPage(KeyEvent &event) const {
 void PinyinEngine::updateFilter(InputContext *inputContext) {
     auto *state = inputContext->propertyFor(&factory_);
     auto &inputPanel = inputContext->inputPanel();
+    const bool strokeFilterActive = isStrokeFilterActive(inputContext);
 
     updatePreedit(inputContext);
     Text aux;
-    if (state->mode_ == PinyinMode::StrokeFilter) {
+    if (strokeFilterActive) {
         aux.append(_("[Stroke Filtering]"));
         aux.append(pinyinhelper()->call<IPinyinHelper::prettyStrokeString>(
             state->strokeBuffer_.userInput()));
@@ -1613,17 +1611,18 @@ void PinyinEngine::updateFilter(InputContext *inputContext) {
     if (candidateList) {
         auto *pinyinTabbed = dynamic_cast<PinyinTabbedCandidateList *>(
             candidateList->toTabbed());
-        if (state->strokeBuffer_.empty() &&
+        if ((!strokeFilterActive || state->strokeBuffer_.empty()) &&
             (!pinyinTabbed || !pinyinTabbed->checked())) {
             candidateList->clearFilter();
         } else {
-            candidateList->setFilter([this, pinyinTabbed,
-                                      state](const CandidateWord &candidate)
+            candidateList->setFilter([this, pinyinTabbed, state,
+                                      strokeFilterActive](
+                                         const CandidateWord &candidate)
                                          -> bool {
                 if (pinyinTabbed && !pinyinTabbed->filter(candidate)) {
                     return false;
                 }
-                if (!state->strokeBuffer_.empty()) {
+                if (strokeFilterActive && !state->strokeBuffer_.empty()) {
                     // For stroke candidate, skip if we are doing stroke filter.
                     if (dynamic_cast<const StrokeCandidateWord *>(&candidate)) {
                         return false;
@@ -1704,10 +1703,28 @@ void PinyinEngine::updateForgetCandidate(InputContext *inputContext) {
 
 void PinyinEngine::resetStroke(InputContext *inputContext) const {
     auto *state = inputContext->propertyFor(&factory_);
+    state->strokeCandidateList_.reset();
     state->strokeBuffer_.clear();
-    if (state->mode_ == PinyinMode::StrokeFilter) {
-        state->mode_ = PinyinMode::Normal;
+}
+
+bool PinyinEngine::isStrokeFilterActive(InputContext *inputContext) const {
+    auto *state = inputContext->propertyFor(&factory_);
+    auto candidateList = inputContext->inputPanel().candidateList();
+    return candidateList && state->strokeCandidateList_.lock() == candidateList;
+}
+
+bool PinyinEngine::startStrokeFilter(InputContext *inputContext) {
+    auto candidateList = inputContext->inputPanel().candidateList();
+    if (!candidateList || candidateList->empty() || !candidateList->toBulk() ||
+        !pinyinhelper()) {
+        return false;
     }
+
+    auto *state = inputContext->propertyFor(&factory_);
+    resetStroke(inputContext);
+    state->strokeCandidateList_ = candidateList;
+    updateFilter(inputContext);
+    return true;
 }
 
 void PinyinEngine::resetForgetCandidate(InputContext *inputContext) const {
@@ -1797,25 +1814,15 @@ void PinyinEngine::deleteCustomPhrase(InputContext *inputContext,
 bool PinyinEngine::handleStrokeFilter(
     KeyEvent &event, const std::shared_future<uint32_t> &keyChr) {
     auto *inputContext = event.inputContext();
-    auto candidateList = inputContext->inputPanel().candidateList();
     auto *state = inputContext->propertyFor(&factory_);
-    if (state->mode_ == PinyinMode::Normal) {
-        if (candidateList && !candidateList->empty() &&
-            candidateList->toBulk() &&
-            event.key().checkKeyList(*config_.selectByStroke) &&
-            pinyinhelper()) {
-            resetStroke(inputContext);
-            state->mode_ = PinyinMode::StrokeFilter;
-            updateFilter(inputContext);
+    if (!isStrokeFilterActive(inputContext)) {
+        if (event.key().checkKeyList(*config_.selectByStroke) &&
+            startStrokeFilter(inputContext)) {
             handleNextPage(event);
 
             event.filterAndAccept();
             return true;
         }
-        return false;
-    }
-
-    if (state->mode_ != PinyinMode::StrokeFilter) {
         return false;
     }
 

--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -374,7 +374,7 @@ struct EventSourceTime;
 class CandidateList;
 class PinyinEngine;
 
-enum class PinyinMode { Normal, StrokeFilter, ForgetCandidate, Punctuation };
+enum class PinyinMode { Normal, ForgetCandidate, Punctuation };
 
 class PinyinState : public InputContextProperty {
 public:
@@ -385,7 +385,8 @@ public:
 
     PinyinMode mode_ = PinyinMode::Normal;
 
-    // Stroke filter
+    // Stroke filter is only active while its target candidate list is current.
+    std::weak_ptr<CandidateList> strokeCandidateList_;
     InputBuffer strokeBuffer_;
 
     // Forget candidate
@@ -445,6 +446,8 @@ public:
     void updateUI(InputContext *inputContext);
     void updateFilter(InputContext *inputContext);
 
+    bool startStrokeFilter(InputContext *inputContext);
+    bool isStrokeFilterActive(InputContext *inputContext) const;
     void resetStroke(InputContext *inputContext) const;
     void resetForgetCandidate(InputContext *inputContext) const;
     void forgetCandidate(InputContext *inputContext, size_t index);

--- a/im/pinyin/pinyincandidate.cpp
+++ b/im/pinyin/pinyincandidate.cpp
@@ -485,8 +485,7 @@ PinyinTabbedCandidateList::PinyinTabbedCandidateList(
       candidateList_(candidateList) {}
 
 std::span<const CandidateAction> PinyinTabbedCandidateList::tabActions() {
-    auto *state = inputContext_->propertyFor(&engine_->factory());
-    if (state->mode_ == PinyinMode::StrokeFilter) {
+    if (engine_->isStrokeFilterActive(inputContext_)) {
         return strokeActions_;
     }
     if (!actions_) {
@@ -634,16 +633,16 @@ void PinyinTabbedCandidateList::triggerTabAction(int id) {
     }
 
     auto *state = inputContext_->propertyFor(&engine_->factory());
-    if (state->mode_ == PinyinMode::StrokeFilter) {
+    if (engine_->isStrokeFilterActive(inputContext_)) {
         triggerStrokeAction(state, id);
     } else {
-        triggerMainAction(state, id);
+        triggerMainAction(id);
     }
 }
 
 void PinyinTabbedCandidateList::triggerStrokeAction(PinyinState *state,
                                                     int id) {
-    assert(state->mode_ == PinyinMode::StrokeFilter);
+    assert(engine_->isStrokeFilterActive(inputContext_));
 
     switch (id) {
     case STROKE_SUB_ACTION_H:
@@ -674,14 +673,15 @@ std::optional<int> PinyinTabbedCandidateList::idToActionIndex(int id) const {
     return std::nullopt;
 }
 
-void PinyinTabbedCandidateList::triggerMainAction(PinyinState *state, int id) {
+void PinyinTabbedCandidateList::triggerMainAction(int id) {
     if (!actions_) {
         return;
     }
     std::optional<int> checkableActionIndex;
     // negative id is special action.
     if (id == STROKE_ACTION) {
-        state->mode_ = PinyinMode::StrokeFilter;
+        engine_->startStrokeFilter(inputContext_);
+        return;
     } else if (checkableActionIndex = idToActionIndex(id);
                !checkableActionIndex) {
         return;

--- a/im/pinyin/pinyincandidate.h
+++ b/im/pinyin/pinyincandidate.h
@@ -305,7 +305,7 @@ public:
 
 private:
     void triggerStrokeAction(PinyinState *state, int id);
-    void triggerMainAction(PinyinState *state, int id);
+    void triggerMainAction(int id);
 
     std::optional<int> idToActionIndex(int id) const;
 

--- a/test/testpinyin.cpp
+++ b/test/testpinyin.cpp
@@ -309,6 +309,39 @@ void testActionInStrokeFilter(Instance *instance) {
     });
 }
 
+void testStrokeFilterOnPrediction(Instance *instance) {
+    instance->eventDispatcher().schedule([instance]() {
+        auto *pinyin = instance->addonManager().addon("pinyin");
+        FCITX_ASSERT(pinyin);
+        RawConfig config;
+        config.setValueByPath("Prediction", "True");
+        pinyin->setConfig(config);
+
+        auto *testfrontend = instance->addonManager().addon("testfrontend");
+        auto uuid =
+            testfrontend->call<ITestFrontend::createInputContext>("testapp");
+        auto *ic = instance->inputContextManager().findByUUID(uuid);
+        FCITX_ASSERT(ic);
+        instance->setCurrentInputMethod(ic, "pinyin", true);
+
+        testfrontend->call<ITestFrontend::pushCommitExpectation>("你");
+        testfrontend->call<ITestFrontend::keyEvent>(uuid, Key("n"), false);
+        testfrontend->call<ITestFrontend::keyEvent>(uuid, Key("i"), false);
+        findAndSelectCandidate(ic, "你");
+
+        auto predictionCandidateList = ic->inputPanel().candidateList();
+        FCITX_ASSERT(predictionCandidateList);
+        FCITX_ASSERT(!predictionCandidateList->empty());
+
+        testfrontend->call<ITestFrontend::keyEvent>(uuid, Key("grave"), false);
+        FCITX_ASSERT(ic->inputPanel().candidateList() !=
+                     predictionCandidateList);
+
+        config.setValueByPath("Prediction", "False");
+        pinyin->setConfig(config);
+    });
+}
+
 void testPinyinTabFilter(Instance *instance) {
     instance->eventDispatcher().schedule([instance]() {
         auto *pinyin = instance->addonManager().addon("pinyin");
@@ -673,6 +706,7 @@ int main() {
     testSelectByChar(&instance);
     testUppercase(&instance);
     testForget(&instance);
+    testStrokeFilterOnPrediction(&instance);
     testActionInStrokeFilter(&instance);
     testPinyinTabFilter(&instance);
     testPinyinTabFilterWithSeparator(&instance);


### PR DESCRIPTION
The first commit preserves stroke filter on prediction and only fixes the stroke state reset.
The second commit disables stroke filter on prediction. New test fails without pinyin.cpp change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stroke filtering when working with predicted candidates.
  * Preserved stroke-filter state more reliably while switching between candidate lists.
  * Improved entering and exiting stroke-filter mode through keyboard actions.

* **Tests**
  * Added coverage for starting stroke filtering from prediction results and verifying the displayed candidates update correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->