### PR TITLE
Refactor stroke state handling

### DIFF
--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -192,6 +192,14 @@ bool isStroke(const std::string &input) {
                        [](char c) { return py.count(c); });
 }
 
+PinyinTabbedCandidateList *currentPinyinTabbed(InputContext *inputContext) {
+    auto candidateList = inputContext->inputPanel().candidateList();
+    if (!candidateList) {
+        return nullptr;
+    }
+    return dynamic_cast<PinyinTabbedCandidateList *>(candidateList->toTabbed());
+}
+
 std::string getEncodedPinyin(const libime::SentenceResult &result) {
     std::string encodedPinyin;
     bool validPinyin = std::all_of(
@@ -519,9 +527,6 @@ void PinyinEngine::updatePuncCandidate(
 
 void PinyinEngine::updateUI(InputContext *inputContext) {
     auto *state = inputContext->propertyFor(&factory_);
-    if (state->mode_ == PinyinMode::StrokeFilter) {
-        resetStroke(inputContext);
-    }
     inputContext->inputPanel().reset();
     // Use const ref to avoid accidentally change anything.
     const auto &context = state->context_;
@@ -1595,15 +1600,15 @@ bool PinyinEngine::handleNextPage(KeyEvent &event) const {
 }
 
 void PinyinEngine::updateFilter(InputContext *inputContext) {
-    auto *state = inputContext->propertyFor(&factory_);
     auto &inputPanel = inputContext->inputPanel();
+    auto *pinyinTabbed = currentPinyinTabbed(inputContext);
 
     updatePreedit(inputContext);
     Text aux;
-    if (state->mode_ == PinyinMode::StrokeFilter) {
+    if (pinyinTabbed && pinyinTabbed->inStrokeFilterMode() && pinyinhelper()) {
         aux.append(_("[Stroke Filtering]"));
         aux.append(pinyinhelper()->call<IPinyinHelper::prettyStrokeString>(
-            state->strokeBuffer_.userInput()));
+            pinyinTabbed->strokeBuffer()));
     }
     inputPanel.setAuxUp(aux);
     inputPanel.setAuxDown(Text());
@@ -1611,46 +1616,13 @@ void PinyinEngine::updateFilter(InputContext *inputContext) {
     auto *candidateList =
         dynamic_cast<CommonCandidateList *>(inputPanel.candidateList().get());
     if (candidateList) {
-        auto *pinyinTabbed = dynamic_cast<PinyinTabbedCandidateList *>(
-            candidateList->toTabbed());
-        if (state->strokeBuffer_.empty() &&
-            (!pinyinTabbed || !pinyinTabbed->checked())) {
+        if (!pinyinTabbed || !pinyinTabbed->hasFilter()) {
             candidateList->clearFilter();
         } else {
-            candidateList->setFilter([this, pinyinTabbed,
-                                      state](const CandidateWord &candidate)
-                                         -> bool {
-                if (pinyinTabbed && !pinyinTabbed->filter(candidate)) {
-                    return false;
-                }
-                if (!state->strokeBuffer_.empty()) {
-                    // For stroke candidate, skip if we are doing stroke filter.
-                    if (dynamic_cast<const StrokeCandidateWord *>(&candidate)) {
-                        return false;
-                    }
-                    auto str = candidate.text().toStringForCommit();
-                    if (auto length = utf8::lengthValidated(str);
-                        length != utf8::INVALID_LENGTH && length >= 1) {
-                        auto charRange = utf8::MakeUTF8CharRange(str);
-                        for (auto iter = std::begin(charRange),
-                                  end = std::end(charRange);
-                             iter != end; ++iter) {
-                            std::string chr(iter.charRange().first,
-                                            iter.charRange().second);
-                            auto stroke =
-                                pinyinhelper()
-                                    ->call<IPinyinHelper::reverseLookupStroke>(
-                                        chr);
-                            if (stroke.starts_with(
-                                    state->strokeBuffer_.userInput())) {
-                                return true;
-                            }
-                        }
-                    }
-                    return false;
-                }
-                return true;
-            });
+            candidateList->setFilter(
+                [pinyinTabbed](const CandidateWord &candidate) -> bool {
+                    return pinyinTabbed->filter(candidate);
+                });
         }
 
         if (candidateList->totalPages() > 0) {
@@ -1700,14 +1672,6 @@ void PinyinEngine::updateForgetCandidate(InputContext *inputContext) {
     inputContext->inputPanel().setCandidateList(std::move(candidateList));
     inputContext->updatePreedit();
     inputContext->updateUserInterface(UserInterfaceComponent::InputPanel);
-}
-
-void PinyinEngine::resetStroke(InputContext *inputContext) const {
-    auto *state = inputContext->propertyFor(&factory_);
-    state->strokeBuffer_.clear();
-    if (state->mode_ == PinyinMode::StrokeFilter) {
-        state->mode_ = PinyinMode::Normal;
-    }
 }
 
 void PinyinEngine::resetForgetCandidate(InputContext *inputContext) const {
@@ -1772,7 +1736,6 @@ void PinyinEngine::pinCustomPhrase(InputContext *inputContext,
     const auto py = context.userInput().substr(selectedLength, pyLength);
     customPhrase_.pinPhrase(py, customPhrase);
 
-    resetStroke(inputContext);
     updateUI(inputContext);
     saveCustomPhrase();
 }
@@ -1789,7 +1752,6 @@ void PinyinEngine::deleteCustomPhrase(InputContext *inputContext,
     const auto py = context.userInput().substr(selectedLength, pyLength);
     customPhrase_.removePhrase(py, customPhrase);
 
-    resetStroke(inputContext);
     updateUI(inputContext);
     saveCustomPhrase();
 }
@@ -1799,13 +1761,29 @@ bool PinyinEngine::handleStrokeFilter(
     auto *inputContext = event.inputContext();
     auto candidateList = inputContext->inputPanel().candidateList();
     auto *state = inputContext->propertyFor(&factory_);
-    if (state->mode_ == PinyinMode::Normal) {
-        if (candidateList && !candidateList->empty() &&
-            candidateList->toBulk() &&
-            event.key().checkKeyList(*config_.selectByStroke) &&
-            pinyinhelper()) {
-            resetStroke(inputContext);
-            state->mode_ = PinyinMode::StrokeFilter;
+    auto *pinyinTabbed = currentPinyinTabbed(inputContext);
+
+    // Any candidate list without PinyinTabbedCandidateList will not be able to
+    // enter stroke filter mode.
+    if (!pinyinTabbed) {
+        return false;
+    }
+
+    // Stroke relies on PinyinHelper.
+    if (!pinyinhelper()) {
+        return false;
+    }
+
+    // Only available in normal mode.
+    if (state->mode_ != PinyinMode::Normal) {
+        return false;
+    }
+
+    if (!pinyinTabbed->inStrokeFilterMode()) {
+        assert(candidateList);
+        if (!candidateList->empty() && candidateList->toBulk() &&
+            event.key().checkKeyList(*config_.selectByStroke)) {
+            pinyinTabbed->setStrokeFilterMode();
             updateFilter(inputContext);
             handleNextPage(event);
 
@@ -1815,19 +1793,19 @@ bool PinyinEngine::handleStrokeFilter(
         return false;
     }
 
-    if (state->mode_ != PinyinMode::StrokeFilter) {
+    // If we are still not in stroke filter mode, return.
+    if (!pinyinTabbed->inStrokeFilterMode()) {
         return false;
     }
 
     event.filterAndAccept();
     // A special case that allow prev page to quit stroke filtering.
-    if ((state->strokeBuffer_.empty() &&
+    if ((pinyinTabbed->strokeBuffer().empty() &&
          event.key().checkKeyList(*config_.prevPage))) {
         auto candidateList = inputContext->inputPanel().candidateList();
         if (candidateList && candidateList->toPageable() &&
             candidateList->toPageable()->currentPage() <= 1) {
-            resetStroke(inputContext);
-            updateUI(inputContext);
+            pinyinTabbed->resetStrokeFilterMode();
             return true;
         }
     }
@@ -1841,18 +1819,13 @@ bool PinyinEngine::handleStrokeFilter(
     }
 
     if (event.key().check(FcitxKey_Escape)) {
-        resetStroke(inputContext);
-        updateUI(inputContext);
+        pinyinTabbed->resetStrokeFilterMode();
         return true;
     }
     if (event.key().check(FcitxKey_BackSpace)) {
         // Do backspace is stroke is not empty.
-        if (!state->strokeBuffer_.empty()) {
-            state->strokeBuffer_.backspace();
-            updateFilter(inputContext);
-        } else {
+        if (!pinyinTabbed->popStroke()) {
             // Exit stroke mode when stroke buffer is empty.
-            resetStroke(inputContext);
             updateUI(inputContext);
         }
         return true;
@@ -1874,8 +1847,7 @@ bool PinyinEngine::handleStrokeFilter(
             {FcitxKey_z, '5'}};
         if (auto iter = strokeMap.find(event.key().sym());
             iter != strokeMap.end()) {
-            state->strokeBuffer_.type(iter->second);
-            updateFilter(inputContext);
+            pinyinTabbed->pushStroke(iter->second);
         }
     }
 
@@ -2423,7 +2395,6 @@ void PinyinEngine::reset(const InputMethodEntry & /*entry*/,
 
 void PinyinEngine::doReset(InputContext *inputContext) const {
     auto *state = inputContext->propertyFor(&factory_);
-    resetStroke(inputContext);
     resetForgetCandidate(inputContext);
     state->mode_ = PinyinMode::Normal;
     state->context_.clear();

--- a/im/pinyin/pinyin.h
+++ b/im/pinyin/pinyin.h
@@ -37,7 +37,6 @@
 #include <fcitx/inputmethodengine.h>
 #include <fcitx/instance.h>
 #include <fcitx/text.h>
-#include <filesystem>
 #include <future>
 #include <libime/core/historybigram.h>
 #include <libime/pinyin/pinyincontext.h>
@@ -49,7 +48,6 @@
 #include <regex>
 #include <string>
 #include <string_view>
-#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -374,7 +372,7 @@ struct EventSourceTime;
 class CandidateList;
 class PinyinEngine;
 
-enum class PinyinMode { Normal, StrokeFilter, ForgetCandidate, Punctuation };
+enum class PinyinMode { Normal, ForgetCandidate, Punctuation };
 
 class PinyinState : public InputContextProperty {
 public:
@@ -384,9 +382,6 @@ public:
     bool lastIsPunc_ = false;
 
     PinyinMode mode_ = PinyinMode::Normal;
-
-    // Stroke filter
-    InputBuffer strokeBuffer_;
 
     // Forget candidate
     std::shared_ptr<CandidateList> forgetCandidateList_;
@@ -445,7 +440,6 @@ public:
     void updateUI(InputContext *inputContext);
     void updateFilter(InputContext *inputContext);
 
-    void resetStroke(InputContext *inputContext) const;
     void resetForgetCandidate(InputContext *inputContext) const;
     void forgetCandidate(InputContext *inputContext, size_t index);
     void pinCustomPhrase(InputContext *inputContext,
@@ -454,6 +448,7 @@ public:
                             const std::string &customPhrase);
 
     FCITX_ADDON_DEPENDENCY_LOADER(cloudpinyin, instance_->addonManager());
+    FCITX_ADDON_DEPENDENCY_LOADER(pinyinhelper, instance_->addonManager());
 
     const auto &selectionKeys() const { return selectionKeys_; }
 
@@ -530,7 +525,6 @@ private:
     FCITX_ADDON_DEPENDENCY_LOADER(chttrans, instance_->addonManager());
     FCITX_ADDON_DEPENDENCY_LOADER(punctuation, instance_->addonManager());
     FCITX_ADDON_DEPENDENCY_LOADER(notifications, instance_->addonManager());
-    FCITX_ADDON_DEPENDENCY_LOADER(pinyinhelper, instance_->addonManager());
     FCITX_ADDON_DEPENDENCY_LOADER(spell, instance_->addonManager());
     FCITX_ADDON_DEPENDENCY_LOADER(imeapi, instance_->addonManager());
 

--- a/im/pinyin/pinyincandidate.cpp
+++ b/im/pinyin/pinyincandidate.cpp
@@ -8,6 +8,7 @@
 #include "pinyincandidate.h"
 #include "../../modules/cloudpinyin/cloudpinyin_public.h"
 #include "pinyin.h"
+#include "pinyinhelper_public.h"
 #include <algorithm>
 #include <boost/container_hash/hash.hpp>
 #include <cassert>
@@ -18,6 +19,7 @@
 #include <fcitx-utils/eventloopinterface.h>
 #include <fcitx-utils/i18n.h>
 #include <fcitx-utils/log.h>
+#include <fcitx-utils/utf8.h>
 #include <fcitx/candidateaction.h>
 #include <fcitx/candidatelist.h>
 #include <fcitx/inputcontext.h>
@@ -485,8 +487,7 @@ PinyinTabbedCandidateList::PinyinTabbedCandidateList(
       candidateList_(candidateList) {}
 
 std::span<const CandidateAction> PinyinTabbedCandidateList::tabActions() {
-    auto *state = inputContext_->propertyFor(&engine_->factory());
-    if (state->mode_ == PinyinMode::StrokeFilter) {
+    if (inStrokeFilterMode()) {
         return strokeActions_;
     }
     if (!actions_) {
@@ -633,17 +634,15 @@ void PinyinTabbedCandidateList::triggerTabAction(int id) {
         return;
     }
 
-    auto *state = inputContext_->propertyFor(&engine_->factory());
-    if (state->mode_ == PinyinMode::StrokeFilter) {
-        triggerStrokeAction(state, id);
+    if (inStrokeFilterMode()) {
+        triggerStrokeAction(id);
     } else {
-        triggerMainAction(state, id);
+        triggerMainAction(id);
     }
 }
 
-void PinyinTabbedCandidateList::triggerStrokeAction(PinyinState *state,
-                                                    int id) {
-    assert(state->mode_ == PinyinMode::StrokeFilter);
+void PinyinTabbedCandidateList::triggerStrokeAction(int id) {
+    assert(inStrokeFilterMode());
 
     switch (id) {
     case STROKE_SUB_ACTION_H:
@@ -651,15 +650,27 @@ void PinyinTabbedCandidateList::triggerStrokeAction(PinyinState *state,
     case STROKE_SUB_ACTION_P:
     case STROKE_SUB_ACTION_N:
     case STROKE_SUB_ACTION_Z:
-        state->strokeBuffer_.type(STROKE_SUB_ACTION_H - id + '1');
+        pushStroke(STROKE_SUB_ACTION_H - id + '1');
         break;
     case STROKE_SUB_ACTION_RETURN:
-        engine_->resetStroke(inputContext_);
+        resetStrokeFilterMode();
         break;
     default:
         return;
     }
+}
+
+void PinyinTabbedCandidateList::pushStroke(char stroke) {
+    strokeBuffer_.type(stroke);
     engine_->updateFilter(inputContext_);
+}
+
+bool PinyinTabbedCandidateList::popStroke() {
+    if (strokeBuffer_.backspace()) {
+        engine_->updateFilter(inputContext_);
+        return true;
+    }
+    return false;
 }
 
 std::optional<int> PinyinTabbedCandidateList::idToActionIndex(int id) const {
@@ -674,14 +685,14 @@ std::optional<int> PinyinTabbedCandidateList::idToActionIndex(int id) const {
     return std::nullopt;
 }
 
-void PinyinTabbedCandidateList::triggerMainAction(PinyinState *state, int id) {
+void PinyinTabbedCandidateList::triggerMainAction(int id) {
     if (!actions_) {
         return;
     }
     std::optional<int> checkableActionIndex;
     // negative id is special action.
     if (id == STROKE_ACTION) {
-        state->mode_ = PinyinMode::StrokeFilter;
+        setStrokeFilterMode();
     } else if (checkableActionIndex = idToActionIndex(id);
                !checkableActionIndex) {
         return;
@@ -712,7 +723,8 @@ void PinyinTabbedCandidateList::triggerMainAction(PinyinState *state, int id) {
     engine_->updateFilter(inputContext_);
 }
 
-bool PinyinTabbedCandidateList::filter(const CandidateWord &candidate) const {
+bool PinyinTabbedCandidateList::filterByCheckedAction(
+    const CandidateWord &candidate) const {
     if (!checked()) {
         return true;
     }
@@ -743,6 +755,53 @@ bool PinyinTabbedCandidateList::filter(const CandidateWord &candidate) const {
     }
 
     return true;
+}
+
+bool PinyinTabbedCandidateList::filterByStroke(
+    const CandidateWord &candidate) const {
+    if (!engine_->pinyinhelper()) {
+        return true;
+    }
+
+    if (!inStrokeFilterMode() || strokeBuffer_.empty()) {
+        return true;
+    }
+
+    // For stroke candidates, skip if we are doing stroke filter.
+    if (dynamic_cast<const StrokeCandidateWord *>(&candidate)) {
+        return false;
+    }
+
+    auto str = candidate.text().toStringForCommit();
+    if (auto length = utf8::lengthValidated(str);
+        length != utf8::INVALID_LENGTH && length >= 1) {
+        auto charRange = utf8::MakeUTF8CharRange(str);
+        for (auto iter = std::begin(charRange), end = std::end(charRange);
+             iter != end; ++iter) {
+            std::string chr(iter.charRange().first, iter.charRange().second);
+            auto stroke = engine_->pinyinhelper()
+                              ->call<IPinyinHelper::reverseLookupStroke>(chr);
+            if (stroke.starts_with(strokeBuffer_.userInput())) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool PinyinTabbedCandidateList::filter(const CandidateWord &candidate) const {
+    return filterByCheckedAction(candidate) && filterByStroke(candidate);
+}
+
+void PinyinTabbedCandidateList::setStrokeFilterMode() {
+    strokeBuffer_.clear();
+    strokeFilterMode_ = true;
+}
+
+void PinyinTabbedCandidateList::resetStrokeFilterMode() {
+    strokeBuffer_.clear();
+    strokeFilterMode_ = false;
+    engine_->updateFilter(inputContext_);
 }
 
 } // namespace fcitx

--- a/im/pinyin/pinyincandidate.h
+++ b/im/pinyin/pinyincandidate.h
@@ -14,6 +14,7 @@
 #include <ctime>
 #include <fcitx-utils/event.h>
 #include <fcitx-utils/eventloopinterface.h>
+#include <fcitx-utils/inputbuffer.h>
 #include <fcitx/candidateaction.h>
 #include <fcitx/candidatelist.h>
 #include <fcitx/inputcontext.h>
@@ -24,7 +25,6 @@
 #include <span>
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -32,7 +32,6 @@
 namespace fcitx {
 
 class PinyinEngine;
-class PinyinState;
 
 class PinyinPredictCandidateWord : public CandidateWord {
 public:
@@ -297,6 +296,17 @@ public:
     std::span<const CandidateAction> tabActions() override;
 
     void triggerTabAction(int id) override;
+    bool inStrokeFilterMode() const { return strokeFilterMode_; }
+    bool hasFilter() const { return checked() || !strokeBuffer_.empty(); }
+    const std::string &strokeBuffer() const {
+        return strokeBuffer_.userInput();
+    }
+    void setStrokeFilterMode();
+    void resetStrokeFilterMode();
+    void pushStroke(char stroke);
+    // Return whether pop is successful.
+    bool popStroke();
+
     bool checked() const {
         return checkedPinyinActionId_.has_value() || checkedSingleAction_;
     }
@@ -304,8 +314,10 @@ public:
     bool filter(const CandidateWord &candidate) const;
 
 private:
-    void triggerStrokeAction(PinyinState *state, int id);
-    void triggerMainAction(PinyinState *state, int id);
+    void triggerStrokeAction(int id);
+    void triggerMainAction(int id);
+    bool filterByCheckedAction(const CandidateWord &candidate) const;
+    bool filterByStroke(const CandidateWord &candidate) const;
 
     std::optional<int> idToActionIndex(int id) const;
 
@@ -332,6 +344,8 @@ private:
     std::vector<CandidateAction> strokeActions_;
     std::optional<int> checkedPinyinActionId_ = std::nullopt;
     bool checkedSingleAction_ = false;
+    bool strokeFilterMode_ = false;
+    InputBuffer strokeBuffer_;
     std::vector<std::unordered_set<int>> actionIdToCandidates_;
 };
 


### PR DESCRIPTION
Since now the stroke is also handled as candidate list filter, it makes
sense to merge stroke filter state into the tabbed candidate list and
simplify lots of state management.

Close #289


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Stroke-based candidate filtering is now managed within the candidate list for more consistent filtering behavior.
  * Stroke filter input and state are preserved while navigating candidates and performing related actions.
  * Candidate filtering now combines checked-action filters with stroke-based reverse lookup.
  * Invalid characters are safely excluded from stroke filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->