### PR TITLE
Lua backend for Cloud Pinyin

### DIFF
--- a/im/pinyin/pinyin.cpp
+++ b/im/pinyin/pinyin.cpp
@@ -608,22 +608,26 @@ void PinyinEngine::updateUI(InputContext *inputContext) {
                 CapabilityFlag::PasswordOrSensitive) &&
             fullResult) {
             using namespace std::placeholders;
-            auto fullPinyin = context.useShuangpin()
-                                  ? context.candidateFullPinyin(0)
-                                  : context.userInput().substr(selectedLength);
-            auto cand = std::make_unique<CustomCloudPinyinCandidateWord>(
-                this, fullPinyin, selectedSentence, inputContext,
-                [this](InputContext *ic, const std::string &selected,
-                       const std::string &word) {
-                    cloudPinyinSelected(ic, selected, word);
-                },
-                CandidateOrder{*config_.cloudPinyinIndex - 1,
-                               customCandidateMap.size()});
-            if (!cand->filled() ||
-                (!cand->word().empty() &&
-                 !customCandidateMap.contains(cand->word()) &&
-                 !context.candidatesToCursorSet().contains(cand->word()))) {
-                customCandidateMap.emplace(cand->word(), std::move(cand));
+            auto fullPinyin = context.candidateFullPinyin(0);
+            if (!fullPinyin.empty()) {
+                const auto &queryPinyin =
+                    context.useShuangpin() ? fullPinyin : pyBeforeCursor;
+                auto cand = std::make_unique<CustomCloudPinyinCandidateWord>(
+                    this, queryPinyin, fullPinyin, pyBeforeCursor,
+                    selectedSentence, pinyinCandidates.front().toString(),
+                    inputContext,
+                    [this](InputContext *ic, const std::string &selected,
+                           const std::string &word) {
+                        cloudPinyinSelected(ic, selected, word);
+                    },
+                    CandidateOrder{*config_.cloudPinyinIndex - 1,
+                                   customCandidateMap.size()});
+                if (!cand->filled() ||
+                    (!cand->word().empty() &&
+                     !customCandidateMap.contains(cand->word()) &&
+                     !context.candidatesToCursorSet().contains(cand->word()))) {
+                    customCandidateMap.emplace(cand->word(), std::move(cand));
+                }
             }
         }
         /// }}}

--- a/im/pinyin/pinyincandidate.cpp
+++ b/im/pinyin/pinyincandidate.cpp
@@ -351,13 +351,16 @@ void PinyinCandidateWord::setPinyinInComment() {
 }
 
 CustomCloudPinyinCandidateWord::CustomCloudPinyinCandidateWord(
-    PinyinEngine *engine, const std::string &pinyin,
-    const std::string &selectedSentence, InputContext *inputContext,
-    CloudPinyinSelectedCallback callback, CandidateOrder order)
-    : CloudPinyinCandidateWord(engine->cloudpinyin(), pinyin, selectedSentence,
+    PinyinEngine *engine, const std::string &queryPinyin,
+    const std::string &fullPinyin, const std::string &input,
+    const std::string &selectedSentence, const std::string &first,
+    InputContext *inputContext, CloudPinyinSelectedCallback callback,
+    CandidateOrder order)
+    : CloudPinyinCandidateWord(engine->cloudpinyin(), queryPinyin, fullPinyin,
+                               input, selectedSentence,
                                *engine->config().keepCloudPinyinPlaceHolder,
-                               inputContext, std::move(callback)),
-      PinyinAbstractCandidateWord(pinyin.size(), order) {
+                               first, inputContext, std::move(callback)),
+      PinyinAbstractCandidateWord(input.size(), order) {
     if (filled() || !*engine->config().cloudPinyinAnimation) {
         return;
     }

--- a/im/pinyin/pinyincandidate.h
+++ b/im/pinyin/pinyincandidate.h
@@ -225,12 +225,12 @@ class CustomCloudPinyinCandidateWord
       public PinyinAbstractCandidateWord,
       public InsertableAsCustomPhraseInterface {
 public:
-    CustomCloudPinyinCandidateWord(PinyinEngine *engine,
-                                   const std::string &pinyin,
-                                   const std::string &selectedSentence,
-                                   InputContext *inputContext,
-                                   CloudPinyinSelectedCallback callback,
-                                   CandidateOrder order);
+    CustomCloudPinyinCandidateWord(
+        PinyinEngine *engine, const std::string &queryPinyin,
+        const std::string &fullPinyin, const std::string &input,
+        const std::string &selectedSentence, const std::string &first,
+        InputContext *inputContext, CloudPinyinSelectedCallback callback,
+        CandidateOrder order);
 
     void select(InputContext *inputContext) const override;
 

--- a/modules/cloudpinyin/CMakeLists.txt
+++ b/modules/cloudpinyin/CMakeLists.txt
@@ -7,6 +7,10 @@ set(CLOUDPINYIN_SOURCES
 if (ENABLE_CLOUDPINYIN)
 add_fcitx5_addon(cloudpinyin ${CLOUDPINYIN_SOURCES})
 target_link_libraries(cloudpinyin Fcitx5::Core Fcitx5::Config PkgConfig::Curl Pthread::Pthread nlohmann_json::nlohmann_json)
+if (TARGET Fcitx5::Module::LuaAddonLoader)
+target_compile_definitions(cloudpinyin PRIVATE -DFCITX_HAS_LUA)
+target_link_libraries(cloudpinyin Fcitx5::Module::LuaAddonLoader)
+endif()
 install(TARGETS cloudpinyin DESTINATION "${CMAKE_INSTALL_LIBDIR}/fcitx5")
 configure_file(cloudpinyin.conf.in.in cloudpinyin.conf.in)
 fcitx5_translate_desktop_file("${CMAKE_CURRENT_BINARY_DIR}/cloudpinyin.conf.in" cloudpinyin.conf)
@@ -15,4 +19,3 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/cloudpinyin.conf" DESTINATION "${FCIT
 
 fcitx5_export_module(CloudPinyin TARGET cloudpinyin BUILD_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}" HEADERS cloudpinyin_public.h INSTALL)
 endif()
-

--- a/modules/cloudpinyin/backend.cpp
+++ b/modules/cloudpinyin/backend.cpp
@@ -6,8 +6,16 @@
  */
 
 #include "backend.h"
+#include <charconv>
 #include <curl/curl.h>
 #include <exception>
+#ifdef FCITX_HAS_LUA
+#include <fcitx-config/rawconfig.h>
+#include <fcitx/addoninstance.h>
+#include <fcitx/addonmanager.h>
+#include <luaaddon_public.h>
+#endif
+#include <algorithm>
 #include <fcitx-utils/misc.h>
 #include <fcitx-utils/stringutils.h>
 #include <format>
@@ -26,20 +34,23 @@ class GoogleBackend : public Backend {
 public:
     explicit GoogleBackend(std::string url) : url_(std::move(url)) {}
 
-    std::string prepareRequest(const std::string &pinyin) override {
+    std::optional<HTTPRequest>
+    prepareRequest(const CloudPinyinRequestContext &context) override {
         const UniqueCPtr<char, curl_free> escaped(
-            curl_escape(pinyin.c_str(), static_cast<int>(pinyin.size())));
+            curl_escape(context.queryPinyin.c_str(),
+                        static_cast<int>(context.queryPinyin.size())));
         if (!escaped) {
-            return {};
+            return std::nullopt;
         }
         const std::string url = stringutils::concat(url_, escaped.get());
-        return url;
+        return HTTPRequest{.url = url};
     }
 
-    std::string parseResult(std::string_view result) override {
+    CloudPinyinResult parseResult(const CloudPinyinRequestContext &,
+                                  const HTTPResponse &response) override {
         try {
-            const auto jv = nlohmann::json::parse(result);
-            return jv.at(1).at(0).at(1).at(0).get<std::string>();
+            const auto jv = nlohmann::json::parse(response.body);
+            return {.text = jv.at(1).at(0).at(1).at(0).get<std::string>()};
         } catch (const std::exception &) {
             return {};
         }
@@ -51,46 +62,186 @@ private:
 
 class BaiduBackend : public Backend {
 public:
-    std::string prepareRequest(const std::string &pinyin) override {
+    std::optional<HTTPRequest>
+    prepareRequest(const CloudPinyinRequestContext &context) override {
         const UniqueCPtr<char, &curl_free> escaped(
-            curl_escape(pinyin.c_str(), static_cast<int>(pinyin.size())));
+            curl_escape(context.queryPinyin.c_str(),
+                        static_cast<int>(context.queryPinyin.size())));
         if (!escaped) {
-            return {};
+            return std::nullopt;
         }
         const std::string url =
             std::format("https://olimenew.baidu.com/"
                         "py?input={}&inputtype=py&resultcoding=utf-8",
                         escaped.get());
-        return url;
+        return HTTPRequest{.url = url};
     }
 
-    std::string parseResult(std::string_view result) override {
+    CloudPinyinResult parseResult(const CloudPinyinRequestContext &,
+                                  const HTTPResponse &response) override {
         try {
-            const auto jv = nlohmann::json::parse(result);
+            const auto jv = nlohmann::json::parse(response.body);
             if (jv.at("status") != "T" || jv.at("errno") != "0") {
                 return {};
             }
-            return jv.at("result").at(0).at(0).at(0).get<std::string>();
+            return {.text =
+                        jv.at("result").at(0).at(0).at(0).get<std::string>()};
         } catch (const std::exception &) {
             return {};
         }
     }
 };
 
+#ifdef FCITX_HAS_LUA
+bool validHTTPToken(std::string_view value) {
+    return !value.empty() &&
+           std::all_of(value.begin(), value.end(), [](unsigned char c) {
+               return c > 0x20 && c < 0x7f &&
+                      std::string_view("()<>@,;:\\\"/[]?={} \t").find(c) ==
+                          std::string_view::npos;
+           });
+}
+
+bool validHeaderValue(std::string_view value) {
+    return value.find('\r') == std::string_view::npos &&
+           value.find('\n') == std::string_view::npos;
+}
+
+class LuaBackend : public Backend {
+public:
+    LuaBackend(fcitx::AddonManager *manager, std::string provider)
+        : manager_(manager), provider_(std::move(provider)) {}
+
+    std::optional<HTTPRequest>
+    prepareRequest(const CloudPinyinRequestContext &context) override {
+        auto *imeapi = manager_->addon("imeapi", true);
+        if (!imeapi) {
+            return std::nullopt;
+        }
+        fcitx::RawConfig config;
+        config["provider"].setValue(provider_);
+        config["pinyin"].setValue(context.fullPinyin);
+        config["input"].setValue(context.input);
+        config["selected"].setValue(context.selected);
+        config["first"].setValue(context.first);
+        if (context.before) {
+            config["before"].setValue(*context.before);
+        }
+        if (context.after) {
+            config["after"].setValue(*context.after);
+        }
+        config["program"].setValue(context.program);
+        config["session"].setValue(context.session);
+        const auto result = imeapi->call<fcitx::ILuaAddon::invokeLuaFunction>(
+            nullptr, "cloudPinyinRequest", config);
+        const auto *url = result.valueByPath("url");
+        if (!url || url->empty()) {
+            return std::nullopt;
+        }
+
+        HTTPRequest request;
+        request.url = *url;
+        if (const auto *method = result.valueByPath("method");
+            method && !method->empty()) {
+            request.method = *method;
+        }
+        if (!validHTTPToken(request.method)) {
+            return std::nullopt;
+        }
+        if (const auto *timeout = result.valueByPath("timeout");
+            timeout && !timeout->empty()) {
+            long value;
+            const auto [ptr, error] = std::from_chars(
+                timeout->data(), timeout->data() + timeout->size(), value);
+            if (error != std::errc{} ||
+                ptr != timeout->data() + timeout->size() || value < 1 ||
+                value > 60) {
+                return std::nullopt;
+            }
+            request.timeout = value;
+        }
+        if (const auto *body = result.valueByPath("body")) {
+            request.body = *body;
+        }
+        if (const auto headers = result.get("headers")) {
+            for (const auto &name : headers->subItems()) {
+                const auto value = headers->get(name);
+                if (!value || !validHTTPToken(name) ||
+                    !validHeaderValue(value->value())) {
+                    return std::nullopt;
+                }
+                request.headers.emplace_back(name, value->value());
+            }
+        }
+        return request;
+    }
+
+    CloudPinyinResult parseResult(const CloudPinyinRequestContext &context,
+                                  const HTTPResponse &response) override {
+        auto *imeapi = manager_->addon("imeapi", true);
+        if (!imeapi) {
+            return {};
+        }
+        fcitx::RawConfig config;
+        config["provider"].setValue(provider_);
+        config["pinyin"].setValue(context.fullPinyin);
+        auto &responseConfig = config["response"];
+        responseConfig["status"].setValue(std::to_string(response.status));
+        responseConfig["body"].setValue(std::string(response.body));
+        for (const auto &[name, value] : response.headers) {
+            responseConfig["headers"][name].setValue(value);
+        }
+        const auto result = imeapi->call<fcitx::ILuaAddon::invokeLuaFunction>(
+            nullptr, "cloudPinyinResponse", config);
+        const auto *text = result.valueByPath("text");
+        if (!text) {
+            return {};
+        }
+        CloudPinyinResult candidate{.text = *text};
+        if (const auto *comment = result.valueByPath("comment")) {
+            candidate.comment = *comment;
+        }
+        return candidate;
+    }
+
+    std::optional<std::string>
+    cacheKey(const CloudPinyinRequestContext &) const override {
+        return std::nullopt;
+    }
+
+private:
+    fcitx::AddonManager *manager_;
+    std::string provider_;
+};
+#endif
+
 } // namespace
 
-std::unique_ptr<Backend> createBackend(CloudPinyinBackend backend) {
+std::shared_ptr<Backend> createBackend(CloudPinyinBackend backend,
+                                       fcitx::AddonManager *manager,
+                                       std::string provider) {
+#ifndef FCITX_HAS_LUA
+    FCITX_UNUSED(manager);
+    FCITX_UNUSED(provider);
+#endif
     switch (backend) {
     case CloudPinyinBackend::Google:
-        return std::make_unique<GoogleBackend>(
+        return std::make_shared<GoogleBackend>(
             "https://www.google.com/inputtools/request?ime=pinyin&text=");
     case CloudPinyinBackend::GoogleCN:
-        return std::make_unique<GoogleBackend>(
+        return std::make_shared<GoogleBackend>(
             "https://www.google.cn/inputtools/request?ime=pinyin&text=");
     case CloudPinyinBackend::Baidu:
-        return std::make_unique<BaiduBackend>();
+        return std::make_shared<BaiduBackend>();
+#ifdef FCITX_HAS_LUA
+    case CloudPinyinBackend::Lua:
+        if (manager) {
+            return std::make_shared<LuaBackend>(manager, std::move(provider));
+        }
+        return nullptr;
+#endif
     }
-    return std::make_unique<GoogleBackend>(
+    return std::make_shared<GoogleBackend>(
         "https://www.google.cn/inputtools/request?ime=pinyin&text=");
 }
 

--- a/modules/cloudpinyin/backend.h
+++ b/modules/cloudpinyin/backend.h
@@ -7,25 +7,72 @@
 #ifndef _CLOUDPINYIN_BACKEND_H_
 #define _CLOUDPINYIN_BACKEND_H_
 
+#include "cloudpinyin_public.h"
 #include <fcitx-config/enum.h>
 #include <fcitx-utils/macros.h>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
+#include <vector>
 
+namespace fcitx {
+class AddonManager;
+}
 namespace fcitx::cloudpinyin {
 
+#ifdef FCITX_HAS_LUA
+FCITX_CONFIG_ENUM(CloudPinyinBackend, Google, GoogleCN, Baidu, Lua);
+#else
 FCITX_CONFIG_ENUM(CloudPinyinBackend, Google, GoogleCN, Baidu);
+#endif
+
+using HTTPHeaders = std::vector<std::pair<std::string, std::string>>;
+
+struct CloudPinyinRequestContext {
+    std::string queryPinyin{};
+    std::string fullPinyin{};
+    std::string input{};
+    std::string selected{};
+    std::string first{};
+    std::optional<std::string> before{};
+    std::optional<std::string> after{};
+    std::string program{};
+    std::string session{};
+};
+
+struct HTTPRequest {
+    std::string url{};
+    std::string method = "GET";
+    HTTPHeaders headers{};
+    std::string body{};
+    long timeout = 10;
+};
+
+struct HTTPResponse {
+    long status;
+    std::string_view body;
+    const HTTPHeaders &headers;
+};
 
 class Backend {
 public:
-    FCITX_NODISCARD virtual std::string
-    prepareRequest(const std::string &pinyin) = 0;
-    virtual std::string parseResult(std::string_view result) = 0;
+    FCITX_NODISCARD virtual std::optional<HTTPRequest>
+    prepareRequest(const CloudPinyinRequestContext &context) = 0;
+    virtual CloudPinyinResult
+    parseResult(const CloudPinyinRequestContext &context,
+                const HTTPResponse &response) = 0;
+    virtual std::optional<std::string>
+    cacheKey(const CloudPinyinRequestContext &context) const {
+        return context.queryPinyin;
+    }
     virtual ~Backend() = default;
 };
 
-std::unique_ptr<Backend> createBackend(CloudPinyinBackend backend);
+std::shared_ptr<Backend> createBackend(CloudPinyinBackend backend,
+                                       fcitx::AddonManager *manager = nullptr,
+                                       std::string provider = {});
 
 } // namespace fcitx::cloudpinyin
 

--- a/modules/cloudpinyin/cloudpinyin.cpp
+++ b/modules/cloudpinyin/cloudpinyin.cpp
@@ -38,11 +38,22 @@ FCITX_DEFINE_LOG_CATEGORY(cloudpinyin, "cloudpinyin");
 constexpr int MAX_ERROR = 10;
 constexpr uint64_t minInUs = 60000000;
 
+std::string sessionID(const fcitx::ICUUID &uuid) {
+    constexpr char hex[] = "0123456789abcdef";
+    std::string result;
+    result.reserve(uuid.size() * 2);
+    for (const auto byte : uuid) {
+        result.push_back(hex[byte >> 4]);
+        result.push_back(hex[byte & 0xf]);
+    }
+    return result;
+}
+
 } // namespace
 
 CloudPinyin::CloudPinyin(fcitx::AddonManager *manager)
     : eventLoop_(manager->eventLoop()),
-      dispatcher_(manager->instance()->eventDispatcher()) {
+      dispatcher_(manager->instance()->eventDispatcher()), manager_(manager) {
     curl_global_init(CURL_GLOBAL_ALL);
 
     backends_.emplace(CloudPinyinBackend::Google,
@@ -70,62 +81,106 @@ CloudPinyin::~CloudPinyin() {}
 
 void CloudPinyin::reloadConfig() {
     readAsIni(config_, "conf/cloudpinyin.conf");
+#ifdef FCITX_HAS_LUA
+    updateLuaBackend();
+#endif
 }
+
+void CloudPinyin::setConfig(const fcitx::RawConfig &config) {
+    config_.load(config, true);
+    fcitx::safeSaveAsIni(config_, "conf/cloudpinyin.conf");
+#ifdef FCITX_HAS_LUA
+    updateLuaBackend();
+#endif
+}
+
+#ifdef FCITX_HAS_LUA
+void CloudPinyin::updateLuaBackend() {
+    backends_[CloudPinyinBackend::Lua] = createBackend(
+        CloudPinyinBackend::Lua, manager_, config_.luaProvider.value());
+}
+#endif
 
 void CloudPinyin::request(const std::string &pinyin,
                           CloudPinyinCallback callback) {
-    if (static_cast<int>(pinyin.size()) < config_.minimumLength.value()) {
-        callback(pinyin, "");
+    requestWithContext(
+        nullptr, pinyin, pinyin, "", "", "",
+        [callback = std::move(callback)](const std::string &requestPinyin,
+                                         const CloudPinyinResult &result) {
+            callback(requestPinyin, result.text);
+        });
+}
+
+void CloudPinyin::requestWithContext(fcitx::InputContext *inputContext,
+                                     const std::string &queryPinyin,
+                                     const std::string &fullPinyin,
+                                     const std::string &input,
+                                     const std::string &selected,
+                                     const std::string &first,
+                                     CloudPinyinResultCallback callback) {
+    CloudPinyinRequestContext context{.queryPinyin = queryPinyin,
+                                      .fullPinyin = fullPinyin,
+                                      .input = input,
+                                      .selected = selected,
+                                      .first = first};
+    if (inputContext) {
+        context.program = inputContext->program();
+        context.session = sessionID(inputContext->uuid());
+        const auto &surrounding = inputContext->surroundingText();
+        if (surrounding.isValid()) {
+            const auto &text = surrounding.text();
+            const auto cursor =
+                utf8::ncharByteLength(text.begin(), surrounding.cursor());
+            context.before = text.substr(0, cursor);
+            context.after = text.substr(cursor);
+        }
+    }
+    requestImpl(context, std::move(callback));
+}
+
+void CloudPinyin::requestImpl(const CloudPinyinRequestContext &context,
+                              CloudPinyinResultCallback callback) {
+    if (static_cast<int>(context.queryPinyin.size()) <
+        config_.minimumLength.value()) {
+        callback(context.queryPinyin, {});
         return;
     }
-    if (auto *value = cache_.find(pinyin)) {
-        callback(pinyin, *value);
-    } else {
-        auto backend = config_.backend.value();
-        auto iter = backends_.find(backend);
-        if (iter == backends_.end() || errorCount_ >= MAX_ERROR) {
-            callback(pinyin, "");
+    auto backend = config_.backend.value();
+    auto iter = backends_.find(backend);
+    if (iter == backends_.end() || !iter->second || errorCount_ >= MAX_ERROR) {
+        callback(context.queryPinyin, {});
+        return;
+    }
+    auto b = iter->second;
+    if (const auto cacheKey = b->cacheKey(context)) {
+        if (auto *value = cache_.find(*cacheKey)) {
+            callback(context.queryPinyin, *value);
             return;
         }
-        auto *b = iter->second.get();
-        if (!thread_->addRequest([proxy = *config_.proxy, b, &pinyin,
-                                  &callback](CurlQueue *queue) {
-                const auto url = b->prepareRequest(pinyin);
-                if (url.empty()) {
+    }
+    if (!thread_->addRequest(
+            [proxy = *config_.proxy, b, &context, &callback](CurlQueue *queue) {
+                const auto request = b->prepareRequest(context);
+                if (!request || !queue->setupRequest(*request, proxy)) {
+                    queue->release();
                     return false;
                 }
-                CLOUDPINYIN_DEBUG() << "Request URL: " << url;
-                if (curl_easy_setopt(queue->curl(), CURLOPT_URL, url.c_str()) !=
-                    CURLE_OK) {
-                    return false;
-                }
-                if (curl_easy_setopt(
-                        queue->curl(), CURLOPT_PROXY,
-                        (proxy.empty() ? nullptr : proxy.data())) != CURLE_OK) {
-                    return false;
-                }
-                queue->setPinyin(pinyin);
+                queue->setContext(context);
+                queue->setBackend(b);
                 queue->setBusy();
                 queue->setCallback(callback);
                 return true;
             })) {
-            callback(pinyin, "");
-        }
+        callback(context.queryPinyin, {});
     }
 }
 
 void CloudPinyin::notifyFinished() {
     dispatcher_.scheduleWithContext(this->watch(), [this]() {
         CurlQueue *item;
-        auto backend = config_.backend.value();
-        auto iter = backends_.find(backend);
-        Backend *b = nullptr;
-        if (iter != backends_.end()) {
-            b = iter->second.get();
-        }
 
         while ((item = thread_->popFinished())) {
-            if (item->httpCode() != 200) {
+            if (!item->succeeded() || item->httpCode() != 200) {
                 errorCount_ += 1;
 
                 if (errorCount_ == MAX_ERROR && resetError_) {
@@ -136,18 +191,23 @@ void CloudPinyin::notifyFinished() {
                 }
             }
 
-            std::string hanzi;
-            if (b) {
-                const std::string_view result(item->result().data(),
-                                              item->result().size());
-                CLOUDPINYIN_DEBUG() << "Request result: " << result;
-                hanzi = b->parseResult(result);
-            } else {
-                hanzi = "";
+            CloudPinyinResult result;
+            const auto backend = item->backend();
+            if (backend) {
+                const HTTPResponse response{
+                    item->httpCode(),
+                    std::string_view(item->result().data(),
+                                     item->result().size()),
+                    item->headers()};
+                CLOUDPINYIN_DEBUG()
+                    << "Request response status: " << response.status;
+                result = backend->parseResult(item->context(), response);
             }
-            item->callback()(item->pinyin(), hanzi);
-            if (!hanzi.empty()) {
-                cache_.insert(item->pinyin(), hanzi);
+            item->callback()(item->context().queryPinyin, result);
+            if (!result.text.empty()) {
+                if (const auto cacheKey = backend->cacheKey(item->context())) {
+                    cache_.insert(*cacheKey, result);
+                }
             }
             item->release();
         }

--- a/modules/cloudpinyin/cloudpinyin.h
+++ b/modules/cloudpinyin/cloudpinyin.h
@@ -42,6 +42,10 @@ FCITX_CONFIGURATION(
                                      _("Minimum Pinyin Length"), 4};
     fcitx::Option<CloudPinyinBackend> backend{this, "Backend", _("Backend"),
                                               CloudPinyinBackend::GoogleCN};
+#ifdef FCITX_HAS_LUA
+    fcitx::Option<std::string> luaProvider{this, "LuaProvider",
+                                           _("Lua Provider"), ""};
+#endif
     fcitx::OptionWithAnnotation<std::string, fcitx::ToolTipAnnotation> proxy{
         this,
         "Proxy",
@@ -61,12 +65,16 @@ public:
 
     void reloadConfig() override;
     const fcitx::Configuration *getConfig() const override { return &config_; }
-    void setConfig(const fcitx::RawConfig &config) override {
-        config_.load(config, true);
-        fcitx::safeSaveAsIni(config_, "conf/cloudpinyin.conf");
-    }
+    void setConfig(const fcitx::RawConfig &config) override;
 
     void request(const std::string &pinyin, CloudPinyinCallback callback);
+    void requestWithContext(fcitx::InputContext *inputContext,
+                            const std::string &queryPinyin,
+                            const std::string &fullPinyin,
+                            const std::string &input,
+                            const std::string &selected,
+                            const std::string &first,
+                            CloudPinyinResultCallback callback);
     const fcitx::KeyList &toggleKey() const {
         return config_.toggleKey.value();
     }
@@ -78,7 +86,13 @@ public:
     void notifyFinished();
 
 private:
+#ifdef FCITX_HAS_LUA
+    void updateLuaBackend();
+#endif
+    void requestImpl(const CloudPinyinRequestContext &context,
+                     CloudPinyinResultCallback callback);
     FCITX_ADDON_EXPORT_FUNCTION(CloudPinyin, request);
+    FCITX_ADDON_EXPORT_FUNCTION(CloudPinyin, requestWithContext);
     FCITX_ADDON_EXPORT_FUNCTION(CloudPinyin, toggleKey);
     FCITX_ADDON_EXPORT_FUNCTION(CloudPinyin, resetError);
     std::unique_ptr<FetchThread> thread_;
@@ -86,10 +100,11 @@ private:
     fcitx::EventDispatcher &dispatcher_;
     std::unique_ptr<fcitx::EventSourceIO> event_;
     std::unique_ptr<fcitx::EventSourceTime> resetError_;
-    LRUCache<std::string, std::string> cache_{2048};
-    std::unordered_map<CloudPinyinBackend, std::unique_ptr<Backend>,
+    LRUCache<std::string, CloudPinyinResult> cache_{2048};
+    std::unordered_map<CloudPinyinBackend, std::shared_ptr<Backend>,
                        fcitx::EnumHash>
         backends_;
+    fcitx::AddonManager *manager_;
     CloudPinyinConfig config_;
     int errorCount_ = 0;
 };

--- a/modules/cloudpinyin/cloudpinyin_public.h
+++ b/modules/cloudpinyin/cloudpinyin_public.h
@@ -25,6 +25,14 @@
 using CloudPinyinCallback =
     std::function<void(const std::string &pinyin, const std::string &hanzi)>;
 
+struct CloudPinyinResult {
+    std::string text{};
+    std::string comment{};
+};
+
+using CloudPinyinResultCallback = std::function<void(
+    const std::string &pinyin, const CloudPinyinResult &result)>;
+
 using CloudPinyinSelectedCallback =
     std::function<void(fcitx::InputContext *inputContext,
                        const std::string &selected, const std::string &word)>;
@@ -32,6 +40,12 @@ using CloudPinyinSelectedCallback =
 FCITX_ADDON_DECLARE_FUNCTION(CloudPinyin, request,
                              void(const std::string &pinyin,
                                   CloudPinyinCallback));
+FCITX_ADDON_DECLARE_FUNCTION(
+    CloudPinyin, requestWithContext,
+    void(fcitx::InputContext *inputContext, const std::string &queryPinyin,
+         const std::string &fullPinyin, const std::string &input,
+         const std::string &selected, const std::string &first,
+         CloudPinyinResultCallback));
 FCITX_ADDON_DECLARE_FUNCTION(CloudPinyin, toggleKey, const fcitx::KeyList &());
 FCITX_ADDON_DECLARE_FUNCTION(CloudPinyin, resetError, void());
 
@@ -39,23 +53,25 @@ class CloudPinyinCandidateWord
     : virtual public fcitx::CandidateWord,
       public fcitx::TrackableObject<CloudPinyinCandidateWord> {
 public:
-    CloudPinyinCandidateWord(fcitx::AddonInstance *cloudpinyin_,
-                             const std::string &pinyin,
-                             std::string selectedSentence, bool keep,
-                             fcitx::InputContext *inputContext,
-                             CloudPinyinSelectedCallback callback)
+    CloudPinyinCandidateWord(
+        fcitx::AddonInstance *cloudpinyin_, const std::string &queryPinyin,
+        const std::string &fullPinyin, const std::string &input,
+        std::string selectedSentence, bool keep, const std::string &first,
+        fcitx::InputContext *inputContext, CloudPinyinSelectedCallback callback)
         : selectedSentence_(std::move(selectedSentence)),
           inputContext_(inputContext), callback_(std::move(callback)),
           keep_(keep) {
         // use cloud unicode char
         setText(fcitx::Text("\xe2\x98\x81"));
-        cloudpinyin_->call<fcitx::ICloudPinyin::request>(
-            pinyin, [ref = watch()](const std::string &pinyin,
-                                    const std::string &hanzi) {
+        cloudpinyin_->call<fcitx::ICloudPinyin::requestWithContext>(
+            inputContext_, queryPinyin, fullPinyin, input, selectedSentence_,
+            first,
+            [ref = watch()](const std::string &pinyin,
+                            const CloudPinyinResult &result) {
                 FCITX_UNUSED(pinyin);
                 auto *self = ref.get();
                 if (self) {
-                    self->fill(hanzi);
+                    self->fill(result);
                 }
             });
         constructor_ = false;
@@ -76,9 +92,12 @@ public:
 private:
     static constexpr long int LOADING_TIME_QUICK_THRESHOLD = 1000;
 
-    void fill(const std::string &hanzi) {
-        setText(fcitx::Text(hanzi));
-        word_ = hanzi;
+    void fill(const CloudPinyinResult &result) {
+        setText(fcitx::Text(result.text));
+        if (!result.comment.empty()) {
+            setComment(fcitx::Text(result.comment));
+        }
+        word_ = result.text;
         filled_ = true;
         if (!constructor_) {
             update();

--- a/modules/cloudpinyin/fetch.h
+++ b/modules/cloudpinyin/fetch.h
@@ -7,6 +7,7 @@
 #ifndef _CLOUDPINYIN_FETCH_H_
 #define _CLOUDPINYIN_FETCH_H_
 
+#include "backend.h"
 #include "cloudpinyin_public.h"
 #include <algorithm>
 #include <cstddef>
@@ -18,6 +19,7 @@
 #include <fcitx-utils/eventdispatcher.h>
 #include <fcitx-utils/eventloopinterface.h>
 #include <fcitx-utils/intrusivelist.h>
+#include <fcitx-utils/misc.h>
 #include <functional>
 #include <iterator>
 #include <memory>
@@ -49,6 +51,9 @@ public:
             (curl_easy_setopt(curl_, CURLOPT_WRITEDATA, this) == CURLE_OK) &&
             (curl_easy_setopt(curl_, CURLOPT_WRITEFUNCTION,
                               &CurlQueue::curlWriteFunction) == CURLE_OK) &&
+            (curl_easy_setopt(curl_, CURLOPT_HEADERDATA, this) == CURLE_OK) &&
+            (curl_easy_setopt(curl_, CURLOPT_HEADERFUNCTION,
+                              &CurlQueue::curlHeaderFunction) == CURLE_OK) &&
             (curl_easy_setopt(curl_, CURLOPT_TIMEOUT, 10L) == CURLE_OK) &&
             (curl_easy_setopt(curl_, CURLOPT_NOSIGNAL, 1L) == CURLE_OK);
         if (!result) {
@@ -56,19 +61,36 @@ public:
         }
     }
 
-    ~CurlQueue() override { curl_easy_cleanup(curl_); }
+    ~CurlQueue() override {
+        release();
+        curl_easy_cleanup(curl_);
+    }
 
     void release() {
         busy_ = false;
         data_.clear();
-        pinyin_.clear();
+        headers_.clear();
+        headerSize_ = 0;
+        context_ = {};
+        requestBody_.clear();
         // make sure lambda is free'd
-        callback_ = CloudPinyinCallback();
+        callback_ = CloudPinyinResultCallback();
+        backend_.reset();
         httpCode_ = 0;
+        curlResult_ = CURLE_OK;
+        curl_easy_setopt(curl_, CURLOPT_HTTPHEADER, nullptr);
+        curl_easy_setopt(curl_, CURLOPT_CUSTOMREQUEST, nullptr);
+        curl_easy_setopt(curl_, CURLOPT_POST, 0L);
+        curl_easy_setopt(curl_, CURLOPT_POSTFIELDS, nullptr);
+        curl_easy_setopt(curl_, CURLOPT_POSTFIELDSIZE, 0L);
+        curl_easy_setopt(curl_, CURLOPT_PROXY, nullptr);
+        requestHeaders_.reset();
     }
 
-    const auto &pinyin() const { return pinyin_; }
-    void setPinyin(std::string pinyin) { pinyin_ = std::move(pinyin); }
+    const auto &context() const { return context_; }
+    void setContext(CloudPinyinRequestContext context) {
+        context_ = std::move(context);
+    }
 
     auto curl() { return curl_; }
     void finish(CURLcode result) {
@@ -79,20 +101,78 @@ public:
     bool busy() const { return busy_; }
     void setBusy() { busy_ = true; }
 
-    const std::vector<char> &result() { return data_; }
+    const std::vector<char> &result() const { return data_; }
+    const HTTPHeaders &headers() const { return headers_; }
 
-    CloudPinyinCallback callback() { return callback_; }
-    void setCallback(CloudPinyinCallback callback) {
+    CloudPinyinResultCallback callback() { return callback_; }
+    void setCallback(CloudPinyinResultCallback callback) {
         callback_ = std::move(callback);
     }
 
     auto httpCode() const { return httpCode_; }
+    bool succeeded() const { return curlResult_ == CURLE_OK; }
+
+    bool setupRequest(const HTTPRequest &request, const std::string &proxy) {
+        if (request.method == "GET" && !request.body.empty()) {
+            return false;
+        }
+        UniqueCPtr<curl_slist, curl_slist_free_all> requestHeaders;
+        for (const auto &[name, value] : request.headers) {
+            auto *oldHeaders = requestHeaders.release();
+            auto *headers =
+                curl_slist_append(oldHeaders, (name + ": " + value).c_str());
+            if (!headers) {
+                requestHeaders.reset(oldHeaders);
+                return false;
+            }
+            requestHeaders.reset(headers);
+        }
+        requestHeaders_ = std::move(requestHeaders);
+        requestBody_ = request.body;
+        const bool hasBody = !requestBody_.empty();
+        const bool isPost = request.method == "POST";
+        const bool needsPostFields = hasBody || isPost;
+        return curl_easy_setopt(curl_, CURLOPT_URL, request.url.c_str()) ==
+                   CURLE_OK &&
+               curl_easy_setopt(curl_, CURLOPT_PROXY,
+                                proxy.empty() ? nullptr : proxy.c_str()) ==
+                   CURLE_OK &&
+               curl_easy_setopt(curl_, CURLOPT_TIMEOUT, request.timeout) ==
+                   CURLE_OK &&
+               curl_easy_setopt(curl_, CURLOPT_HTTPHEADER,
+                                requestHeaders_.get()) == CURLE_OK &&
+               curl_easy_setopt(curl_, CURLOPT_CUSTOMREQUEST,
+                                request.method == "GET"
+                                    ? nullptr
+                                    : request.method.c_str()) == CURLE_OK &&
+               curl_easy_setopt(curl_, CURLOPT_HTTPGET,
+                                !isPost && !hasBody ? 1L : 0L) == CURLE_OK &&
+               (!isPost ||
+                curl_easy_setopt(curl_, CURLOPT_POST, 1L) == CURLE_OK) &&
+               (!needsPostFields ||
+                (curl_easy_setopt(curl_, CURLOPT_POSTFIELDS,
+                                  requestBody_.c_str()) == CURLE_OK &&
+                 curl_easy_setopt(curl_, CURLOPT_POSTFIELDSIZE,
+                                  static_cast<long>(requestBody_.size())) ==
+                     CURLE_OK));
+    }
+
+    void setBackend(std::shared_ptr<Backend> backend) {
+        backend_ = std::move(backend);
+    }
+    const std::shared_ptr<Backend> &backend() const { return backend_; }
 
 private:
     static size_t curlWriteFunction(char *ptr, size_t size, size_t nmemb,
                                     void *userdata) {
         auto *self = static_cast<CurlQueue *>(userdata);
         return self->curlWrite(ptr, size, nmemb);
+    }
+
+    static size_t curlHeaderFunction(char *ptr, size_t size, size_t nmemb,
+                                     void *userdata) {
+        auto *self = static_cast<CurlQueue *>(userdata);
+        return self->curlHeader(ptr, size, nmemb);
     }
 
     size_t curlWrite(char *ptr, size_t size, size_t nmemb) {
@@ -121,13 +201,40 @@ private:
         return realsize;
     }
 
+    size_t curlHeader(char *ptr, size_t size, size_t nmemb) {
+        const size_t realSize = size * nmemb;
+        if (realSize > MAX_BUFFER_SIZE ||
+            headerSize_ > MAX_BUFFER_SIZE - realSize) {
+            return 0;
+        }
+        headerSize_ += realSize;
+        std::string_view header(ptr, realSize);
+        const auto colon = header.find(':');
+        if (colon != std::string_view::npos) {
+            const auto valueStart = header.find_first_not_of(" \t", colon + 1);
+            const auto valueEnd = header.find_last_not_of("\r\n");
+            if (valueStart != std::string_view::npos &&
+                valueEnd != std::string_view::npos && valueStart <= valueEnd) {
+                headers_.emplace_back(
+                    header.substr(0, colon),
+                    header.substr(valueStart, valueEnd - valueStart + 1));
+            }
+        }
+        return realSize;
+    }
+
     bool busy_ = false;
     CURL *curl_ = nullptr;
     CURLcode curlResult_ = CURLE_OK;
     long httpCode_ = 0;
     std::vector<char> data_;
-    std::string pinyin_;
-    CloudPinyinCallback callback_;
+    HTTPHeaders headers_;
+    size_t headerSize_ = 0;
+    CloudPinyinRequestContext context_;
+    std::string requestBody_;
+    UniqueCPtr<curl_slist, curl_slist_free_all> requestHeaders_;
+    CloudPinyinResultCallback callback_;
+    std::shared_ptr<Backend> backend_;
 };
 
 using SetupRequestCallback = std::function<bool(CurlQueue *)>;

--- a/test/testcloudpinyinbackend.cpp
+++ b/test/testcloudpinyinbackend.cpp
@@ -11,60 +11,82 @@ using namespace fcitx::cloudpinyin;
 
 namespace {
 
+CloudPinyinRequestContext requestContext(std::string queryPinyin,
+                                         std::string fullPinyin = {}) {
+    return {.queryPinyin = std::move(queryPinyin),
+            .fullPinyin = std::move(fullPinyin)};
+}
+
 void testGooglePrepareRequest() {
     auto google = createBackend(CloudPinyinBackend::Google);
     auto googleCN = createBackend(CloudPinyinBackend::GoogleCN);
 
     FCITX_ASSERT(
-        google->prepareRequest("nihao") ==
+        google->prepareRequest(requestContext("nihao", "ni'hao"))->url ==
         "https://www.google.com/inputtools/request?ime=pinyin&text=nihao");
     FCITX_ASSERT(
-        googleCN->prepareRequest("nihao") ==
+        googleCN->prepareRequest(requestContext("nihao", "ni'hao"))->url ==
         "https://www.google.cn/inputtools/request?ime=pinyin&text=nihao");
 }
 
 void testGoogleResult() {
     auto backend = createBackend(CloudPinyinBackend::Google);
+    const HTTPHeaders headers;
 
     const auto normalResult = backend->parseResult(
-        R"(["SUCCESS",[["nihao",["你好"],[],{"annotation":["ni hao"],"candidate_type":[0],"lc":["16 16"]}]]])");
-    FCITX_ASSERT(normalResult == "你好");
+        requestContext("nihao"),
+        {200,
+         R"(["SUCCESS",[["nihao",["你好"],[],{"annotation":["ni hao"],"candidate_type":[0],"lc":["16 16"]}]]])",
+         headers});
+    FCITX_ASSERT(normalResult.text == "你好");
 
-    const auto errorResult =
-        backend->parseResult(R"(["FAILED_TO_PARSE_REQUEST_BODY"])");
-    FCITX_ASSERT(errorResult.empty());
+    const auto errorResult = backend->parseResult(
+        requestContext("nihao"),
+        {200, R"(["FAILED_TO_PARSE_REQUEST_BODY"])", headers});
+    FCITX_ASSERT(errorResult.text.empty());
 
-    const auto invalidResult = backend->parseResult("invalid json");
-    FCITX_ASSERT(invalidResult.empty());
+    const auto invalidResult = backend->parseResult(
+        requestContext("nihao"), {200, "invalid json", headers});
+    FCITX_ASSERT(invalidResult.text.empty());
 
-    const auto invalidResult2 = backend->parseResult("");
-    FCITX_ASSERT(invalidResult2.empty());
+    const auto invalidResult2 =
+        backend->parseResult(requestContext("nihao"), {200, "", headers});
+    FCITX_ASSERT(invalidResult2.text.empty());
 }
 
 void testBaiduPrepareRequest() {
     auto backend = createBackend(CloudPinyinBackend::Baidu);
 
-    FCITX_ASSERT(backend->prepareRequest("nihao") ==
-                 "https://olimenew.baidu.com/"
-                 "py?input=nihao&inputtype=py&resultcoding=utf-8");
+    FCITX_ASSERT(
+        backend->prepareRequest(requestContext("nihao", "ni'hao"))->url ==
+        "https://olimenew.baidu.com/"
+        "py?input=nihao&inputtype=py&resultcoding=utf-8");
 }
 
 void testBaiduResult() {
     auto backend = createBackend(CloudPinyinBackend::Baidu);
+    const HTTPHeaders headers;
 
     const auto normalResult = backend->parseResult(
-        R"({"status":"T","errno":"0","errmsg":"","result":[[["结果",6,{"pinyin":"jie'guo","type":"IMEDICT"}]]]})");
-    FCITX_ASSERT(normalResult == "结果");
+        requestContext("jieguo"),
+        {200,
+         R"({"status":"T","errno":"0","errmsg":"","result":[[["结果",6,{"pinyin":"jie'guo","type":"IMEDICT"}]]]})",
+         headers});
+    FCITX_ASSERT(normalResult.text == "结果");
 
     const auto errorResult = backend->parseResult(
-        R"({"status":"F","errno":"3","errmsg":"","result":[]})");
-    FCITX_ASSERT(errorResult.empty());
+        requestContext("jieguo"),
+        {200, R"({"status":"F","errno":"3","errmsg":"","result":[]})",
+         headers});
+    FCITX_ASSERT(errorResult.text.empty());
 
-    const auto invalidResult = backend->parseResult("invalid json");
-    FCITX_ASSERT(invalidResult.empty());
+    const auto invalidResult = backend->parseResult(
+        requestContext("jieguo"), {200, "invalid json", headers});
+    FCITX_ASSERT(invalidResult.text.empty());
 
-    const auto invalidResult2 = backend->parseResult("");
-    FCITX_ASSERT(invalidResult2.empty());
+    const auto invalidResult2 =
+        backend->parseResult(requestContext("jieguo"), {200, "", headers});
+    FCITX_ASSERT(invalidResult2.text.empty());
 }
 
 } // namespace


### PR DESCRIPTION
Closes #248, related: https://github.com/fcitx/fcitx5-lua/pull/35

Test:
~/.local/share/fcitx5/lua/imeapi/extensions/local-cloudpinyin.lua
```lua
local function url_encode(value)
    return (value:gsub("([^%w%-_%.~])", function(c)
        return string.format("%%%02X", string.byte(c))
    end))
end

assert(ime.cloudpinyin_provider_api_version == 1)

assert(ime.register_cloudpinyin_provider(
    "local-http",
    function(context)
        for k, v in pairs(context) do
            io.stderr:write(tostring(k), " = ", tostring(v), "\n")
        end
        return {
            url = "http://127.0.0.1:18765/candidate?pinyin=" ..
                url_encode(context.pinyin),
            timeout = 7,
        }
    end,
    function(response)
        if response.status ~= 200 then
            return nil
        end
        for k, v in pairs(response.headers) do
            io.stderr:write(tostring(k), " = ", tostring(v), "\n")
        end
        local text = response.body:match('"result"%s*:%s*"([^"]*)"')
        if text == nil then
            return nil
        end
        return { text = text, comment = "这是注释" }
    end
))

```
Python server:
```py
import argparse
import json
import logging
from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
from urllib.parse import parse_qs, urlparse


class CandidateHandler(BaseHTTPRequestHandler):
    protocol_version = "HTTP/1.1"

    def do_GET(self) -> None:
        parsed = urlparse(self.path)
        parameters = parse_qs(parsed.query, keep_blank_values=True)
        pinyin = parameters.get("pinyin", [""])[0]
        result = f"这是从 {pinyin} 生成的响应"
        response = json.dumps({"result": result}, ensure_ascii=False).encode()

        logging.info(
            "%s %s parameters=%s response=%s",
            self.command,
            parsed.path,
            parameters,
            response.decode(),
        )
        self.send_response(200)
        self.send_header("Content-Type", "application/json; charset=utf-8")
        self.send_header("Content-Length", str(len(response)))
        self.end_headers()
        self.wfile.write(response)

    def log_message(self, format: str, *args: object) -> None:
        logging.info("%s - %s", self.address_string(), format % args)


def main() -> None:
    parser = argparse.ArgumentParser(description=__doc__)
    parser.add_argument("--host", default="127.0.0.1")
    parser.add_argument("--port", type=int, default=18765)
    args = parser.parse_args()

    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
    server = ThreadingHTTPServer((args.host, args.port), CandidateHandler)
    logging.info("Listening on http://%s:%d/candidate", args.host, args.port)
    try:
        server.serve_forever()
    except KeyboardInterrupt:
        logging.info("Stopping server")
    finally:
        server.server_close()


if __name__ == "__main__":
    main()
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Lua-based cloud Pinyin provider support when available.
  * Cloud Pinyin requests can now use additional input context, including surrounding text and selected content.
  * Cloud results can include candidate text and explanatory comments.
* **Improvements**
  * Improved handling of Pinyin candidates across different input methods, including shuangpin.
  * Enhanced request handling and caching for more reliable cloud Pinyin suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->